### PR TITLE
chore: TS Cleanup / feat: group search pages

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'country-code-emoji' {
+  function countryCodeEmoji(cc: string): string;
+  export = countryCodeEmoji;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,15 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@discordjs/collection": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.3.tgz",
-      "integrity": "sha512-4ek19SmNcPI92942RkuBrZrBK8hg7nG+ae/skkNNDeOaUG+XvxTPkv/jPZVgXwVPDkU5EFsewsI+0n4dTwFvgA=="
-    },
     "@types/node": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.0.tgz",
-      "integrity": "sha512-zwrxviZS08kRX40nqBrmERElF2vpw4IUTd5khkhBTfFH8AOaeoLVx48EC4+ZzS2/Iga7NevncqnsUSYjM4OWYA==",
+      "version": "13.11.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
+      "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==",
       "dev": true
     },
     "@types/strip-bom": {
@@ -27,6 +22,15 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
     },
+    "@types/ws": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.4.tgz",
+      "integrity": "sha512-9S6Ask71vujkVyeEXKxjBSUV8ZUB0mjL5la4IncBoheu04bDaYyUKErh1BQcY9+WzOUOiKqz/OnpJHYckbMfNg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -36,9 +40,9 @@
       }
     },
     "arg": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz",
-      "integrity": "sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg=="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -52,12 +56,11 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "axios": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
       "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
+        "follow-redirects": "1.5.10"
       }
     },
     "balanced-match": {
@@ -161,22 +164,44 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "diff": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "discord.js": {
-      "version": "github:discordjs/discord.js#6a0fe467e5f6e08360bcce0bf3039f01e6dc8678",
-      "from": "github:discordjs/discord.js",
+      "version": "12.1.1",
+      "resolved": "github:discordjs/discord.js#6a0fe467e5f6e08360bcce0bf3039f01e6dc8678",
       "requires": {
-        "@discordjs/collection": "^0.1.1",
+        "@discordjs/collection": "^0.1.5",
         "abort-controller": "^3.0.0",
-        "form-data": "^2.3.3",
-        "node-fetch": "^2.3.0",
-        "prism-media": "^1.0.0",
+        "form-data": "^3.0.0",
+        "node-fetch": "^2.6.0",
+        "prism-media": "^1.2.0",
         "setimmediate": "^1.0.5",
-        "tweetnacl": "^1.0.1",
-        "ws": "^7.2.0"
+        "tweetnacl": "^1.0.3",
+        "ws": "^7.2.1"
+      },
+      "dependencies": {
+        "@discordjs/collection": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.5.tgz",
+          "integrity": "sha512-CU1q0UXQUpFNzNB7gufgoisDHP7n+T3tkqTsp3MNUkVJ5+hS3BCvME8uCXAUFlz+6T2FbTCu75A+yQ7HMKqRKw=="
+        },
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+        }
       }
     },
     "dynamic-dedupe": {
@@ -227,16 +252,6 @@
       "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
         "debug": "=3.1.0"
-      }
-    },
-    "form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
       }
     },
     "fs": {
@@ -319,11 +334,6 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "is-buffer": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-    },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
@@ -375,9 +385,9 @@
       }
     },
     "make-error": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "map-obj": {
       "version": "1.0.1",
@@ -749,15 +759,15 @@
       "dev": true
     },
     "ts-node": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
-      "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.8.2.tgz",
+      "integrity": "sha512-duVj6BpSpUpD/oM4MfhO98ozgkp3Gt9qIp3jGxwU2DFvl/3IRaEAvbLa8G60uS7C77457e/m5TMowjedeRxI1Q==",
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.6",
-        "yn": "^3.0.0"
+        "yn": "3.1.1"
       }
     },
     "ts-node-dev": {
@@ -800,15 +810,10 @@
         }
       }
     },
-    "tweetnacl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-      "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
-    },
     "typescript": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
-      "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw=="
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
     },
     "util": {
       "version": "0.10.4",

--- a/package.json
+++ b/package.json
@@ -10,16 +10,17 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "axios": "^0.19.0",
+    "axios": "^0.19.2",
     "country-code-emoji": "^1.0.0",
-    "discord.js": "github:discordjs/discord.js",
+    "discord.js": "^12.0.0",
     "fs": "0.0.1-security",
     "path": "^0.12.7",
-    "ts-node": "^8.5.4",
-    "typescript": "^3.7.4"
+    "ts-node": "^8.8.2",
+    "typescript": "^3.8.3"
   },
   "devDependencies": {
-    "@types/node": "^13.1.0",
+    "@types/node": "^13.11.1",
+    "@types/ws": "^7.2.4",
     "ts-node-dev": "^1.0.0-pre.44"
   }
 }

--- a/src/common/tools.ts
+++ b/src/common/tools.ts
@@ -87,7 +87,7 @@ class Tools {
 
         //? Return [Message, Channel]
         try {
-            const channel: TextChannel = <TextChannel>guild.channels.find((c) => c.id == channelId)
+            const channel: TextChannel = <TextChannel>guild.channels.cache.find((c) => c.id == channelId)
             const message = await channel.messages.fetch(messageId)
             return [message, channel]
         } catch (error) {
@@ -99,7 +99,7 @@ class Tools {
     }
 
     static async getRoleById(roleId: Snowflake, guild:Discord.Guild) {
-        return guild.roles.find((r) => r.id == roleId)
+        return guild.roles.cache.find((r) => r.id == roleId)
     }
 }
 

--- a/src/events/MemberJoin.ts
+++ b/src/events/MemberJoin.ts
@@ -8,7 +8,7 @@ class MemberJoin {
 
     constructor(member: GuildMember | PartialGuildMember) {
         this.bot = bot;
-        const welcomeChannel = member.guild.channels.find(c => c.name == "where-are-you-from") as TextChannel;
+        const welcomeChannel = member.guild.channels.cache.find(c => c.name == "where-are-you-from") as TextChannel;
         let messages = [`Welcome to the Yes Theory Fam Discord Server ${member.toString()}! What's your name? If you drop where you're from into this chat, you'll be granted full access to all the different channels :heart: You can go over <#450102410262609943> while you wait. In the meantime you can go say hi to a couple of our friends in <#689589205755625641>! :grin:`,
         `Hello there ${member.toString()}! What's your name? Welcome :heart: Don't forget to tell us where you're from so someone can give you full access to the Yes Theory Fam Discord Server! In the meantime, feel free to give <#450102410262609943> a read. In the meantime you can go say hi to a couple of our friends in <#689589205755625641>! :grin:`,
         `Welcome ${member.toString()}! What's your name? You just landed in the Yes Theory Fam Discord Server :grin: Tell us where you're from so you can explore all the different channels. Until that happens, you can take a look at <#450102410262609943>. In the meantime you can go say hi to a couple of our friends in <#689589205755625641>! :heart:`,

--- a/src/events/ReactionAdd.ts
+++ b/src/events/ReactionAdd.ts
@@ -35,11 +35,11 @@ class ReactionAdd {
         const reactRoleObjects = await Tools.resolveFile("reactRoleObjects");
         reactRoleObjects.forEach((element: any) => {
             if (this.messageId === element.messageId && this.reaction === element.reaction) {
-                const guildMember = this.guild.members.find(m => m.id == this.user.id);
-                const roleToAdd = this.guild.roles.find(r => r.id == element.roleId);
-                const groupsHeaderRole = this.guild.roles.find(r => r.id == "603387942702022696")
-                const fiyestasHeaderRole = this.guild.roles.find(r => r.id == "602491235705421844")
-                const badgesHeaderRole = this.guild.roles.find(r => r.id == "602491468795478036")
+                const guildMember = this.guild.members.cache.find(m => m.id == this.user.id);
+                const roleToAdd = this.guild.roles.cache.find(r => r.id == element.roleId);
+                const groupsHeaderRole = this.guild.roles.cache.find(r => r.id == "603387942702022696")
+                const fiyestasHeaderRole = this.guild.roles.cache.find(r => r.id == "602491235705421844")
+                const badgesHeaderRole = this.guild.roles.cache.find(r => r.id == "602491468795478036")
                 guildMember.roles.add(roleToAdd);
                 guildMember.roles.add(groupsHeaderRole);
                 guildMember.roles.add(fiyestasHeaderRole);

--- a/src/events/ReactionRemove.ts
+++ b/src/events/ReactionRemove.ts
@@ -27,8 +27,8 @@ class ReactionRemove {
         const reactRoleObjects = await Tools.resolveFile("reactRoleObjects");
         reactRoleObjects.forEach((element: any) => {
             if (this.messageId === element.messageId && this.reaction === element.reaction) {
-                const guildMember = this.guild.members.find(m => m.id == this.user.id);
-                const roleToAdd = this.guild.roles.find(r => r.id == element.roleId);
+                const guildMember = this.guild.members.cache.find(m => m.id == this.user.id);
+                const roleToAdd = this.guild.roles.cache.find(r => r.id == element.roleId);
                 guildMember.roles.remove(roleToAdd);
             }
         });

--- a/src/programs/AdventureGame.ts
+++ b/src/programs/AdventureGame.ts
@@ -10,11 +10,11 @@ export default async function AdventureGame(user: User, guild: Guild, bot: Clien
 
     const channelName = `game-session-${user.username}`.replace(/\s+/g, '-').toLowerCase();
     const channelOptions = createChannelOptions(user, bot, guild)
-    const attemptedFindChannel = guild.channels.find(c => c.name == channelName);
-    const playingRole = guild.roles.find(r => r.name.toLowerCase().includes("playing"))
-    const guildMember = guild.members.find(m => m.id === user.id)
+    const attemptedFindChannel = guild.channels.cache.find(c => c.name == channelName);
+    const playingRole = guild.roles.cache.find(r => r.name.toLowerCase().includes("playing"))
+    const guildMember = guild.members.cache.find(m => m.id === user.id)
 
-    if(guildMember.roles.has("I lost the game :(") || guildMember.roles.has("Lodiestan! 🏳️") || guildMember.roles.has("The Doravolution! 🏴")) {
+    if(guildMember.roles.cache.has("I lost the game :(") || guildMember.roles.cache.has("Lodiestan! 🏳️") || guildMember.roles.cache.has("The Doravolution! 🏴")) {
         return;
     }
 
@@ -29,7 +29,7 @@ export default async function AdventureGame(user: User, guild: Guild, bot: Clien
     channel.send(`<@${user.id}>`)
     guildMember.roles.add(playingRole);
 
-    guild.roles.find(r => r.name.toLowerCase() === "playing")
+    guild.roles.cache.find(r => r.name.toLowerCase() === "playing")
     const firstMessage = await channel.send(intro);
      firstMessage.react("🧗").then(reaction => firstMessage.react("🧘"))
             
@@ -121,7 +121,7 @@ const dora = async (channel:TextChannel) => {
             const reaction = collected.first();
             switch (reaction.emoji.toString()) {
                 case "⏰":
-                    const user = reaction.users.array()[1];
+                    const user = reaction.users.cache.array()[1];
                     doraWin(channel, user)
                     break;
                 case "🤫":
@@ -143,9 +143,9 @@ const userDied = async (channel:TextChannel) => {
     }, { max: 1, time: 6000000, errors: ['time'] })
         .then(collected => {
             const reaction = collected.first();
-            const user = reaction.users.array()[1];
-            const role = channel.guild.roles.find(r => r.name == "I lost the game :(")
-            const m = channel.guild.members.find(m => m.id == user.id)
+            const user = reaction.users.cache.array()[1];
+            const role = channel.guild.roles.cache.find(r => r.name == "I lost the game :(")
+            const m = channel.guild.members.cache.find(m => m.id == user.id)
             m.roles.add(role);
             removePlaying(m);
             channel.delete("Finished the game");
@@ -153,7 +153,7 @@ const userDied = async (channel:TextChannel) => {
         })
 }
 const removePlaying = (m:GuildMember) => {
-    const role = m.guild.roles.find(r => r.name.toLowerCase().includes("playing"));
+    const role = m.guild.roles.cache.find(r => r.name.toLowerCase().includes("playing"));
     m.roles.remove(role);
 }
 
@@ -195,13 +195,13 @@ const lodeWin = async (channel:TextChannel) => {
     }, { max: 1, time: 6000000, errors: ['time'] })
         .then(collected => {
             const reaction = collected.first();
-            const user = reaction.users.array()[1];
-            const role = channel.guild.roles.find(r => r.id == "694614416553017435")
-            const m = channel.guild.members.find(m => m.id == user.id)
+            const user = reaction.users.cache.array()[1];
+            const role = channel.guild.roles.cache.find(r => r.id == "694614416553017435")
+            const m = channel.guild.members.cache.find(m => m.id == user.id)
             m.roles.add(role)
             removePlaying(m);
             channel.delete("Finished the game");
-            const winnerchannel = <TextChannel>channel.guild.channels.find(c => c.name.toLowerCase() === "lodiestan-plotting")
+            const winnerchannel = <TextChannel>channel.guild.channels.cache.find(c => c.name.toLowerCase() === "lodiestan-plotting")
             winnerchannel.send(`<@${user.id}> has joined our ranks!`)
         })
 }
@@ -214,9 +214,9 @@ const lodeLose = async (channel:TextChannel) => {
     }, { max: 1, time: 6000000, errors: ['time'] })
         .then(collected => {
             const reaction = collected.first();
-            const user = reaction.users.array()[1];
-            const role = channel.guild.roles.find(r => r.name == "I lost the game :(")
-            const m = channel.guild.members.find(m => m.id == user.id)
+            const user = reaction.users.cache.array()[1];
+            const role = channel.guild.roles.cache.find(r => r.name == "I lost the game :(")
+            const m = channel.guild.members.cache.find(m => m.id == user.id)
             m.roles.add(role)
             removePlaying(m);
             channel.delete("Finished the game");
@@ -236,13 +236,13 @@ firstMessage.awaitReactions((reaction: any, user: User) => {
 }, { max: 1, time: 6000000, errors: ['time'] })
     .then(collected => {
         const reaction = collected.first();
-        const user = reaction.users.array()[1];
-        const role = channel.guild.roles.find(r => r.id == "694666400765182002")
-        const m = channel.guild.members.find(m => m.id == user.id)
+        const user = reaction.users.cache.array()[1];
+        const role = channel.guild.roles.cache.find(r => r.id == "694666400765182002")
+        const m = channel.guild.members.cache.find(m => m.id == user.id)
         m.roles.add(role)
         removePlaying(m);
         channel.delete("Finished the game");
-        const winnerchannel = <TextChannel>channel.guild.channels.find(c => c.name.toLowerCase() === "doravolution-plotting")
+        const winnerchannel = <TextChannel>channel.guild.channels.cache.find(c => c.name.toLowerCase() === "doravolution-plotting")
             winnerchannel.send(`<@${user.id}> has joined our ranks!`)
 
     })
@@ -257,9 +257,9 @@ const doraLose = async (channel:TextChannel) => {
     }, { max: 1, time: 6000000, errors: ['time'] })
         .then(collected => {
             const reaction = collected.first();
-            const user = reaction.users.array()[1];
-            const role = channel.guild.roles.find(r => r.name == "I lost the game :(")
-            const m = channel.guild.members.find(m => m.id == user.id)
+            const user = reaction.users.cache.array()[1];
+            const role = channel.guild.roles.cache.find(r => r.name == "I lost the game :(")
+            const m = channel.guild.members.cache.find(m => m.id == user.id)
             m.roles.add(role)
             removePlaying(m);
             channel.delete("Finished the game");

--- a/src/programs/EasterEvent.ts
+++ b/src/programs/EasterEvent.ts
@@ -16,14 +16,14 @@ export default async function EasterEvent(msg: Discord.Message) {
         const channelArray: Channel[] = []
 
         enabledChannels.forEach(channelName => {
-            channelArray.push(msg.guild.channels.find(c => c.name === channelName))
+            channelArray.push(msg.guild.channels.cache.find(c => c.name === channelName))
         })
 
         const randomChannel = <TextChannel>channelArray[Math.floor(Math.random() * enabledChannels.length)]
         const randomMessage = await randomChannel.send(getEggMessage());
-        const modChat = <TextChannel>msg.guild.channels.find(c => c.name === "moderation")
-        const eventChat = <TextChannel>msg.guild.channels.find(c => c.name === "easter-epidemic")
-        const modRole = msg.guild.roles.find(r => r.name === "Support")
+        const modChat = <TextChannel>msg.guild.channels.cache.find(c => c.name === "moderation")
+        const eventChat = <TextChannel>msg.guild.channels.cache.find(c => c.name === "easter-epidemic")
+        const modRole = msg.guild.roles.cache.find(r => r.name === "Support")
 
         let messageAlive = true;
         randomMessage.react("🥚")
@@ -33,7 +33,7 @@ export default async function EasterEvent(msg: Discord.Message) {
             messageAlive = false;
             randomMessage.delete();
             const reaction = collected.first();
-            const member = collected.first().users.array()[1];
+            const member = collected.first().users.cache.array()[1];
             switch (reaction.emoji.toString()) {
                 case "🥚":
                     eventChat.send(`<@${member}> found an egg! Only ${5-eggcount} left to unlock the next emote!`)

--- a/src/programs/ExportManager.ts
+++ b/src/programs/ExportManager.ts
@@ -22,7 +22,7 @@ export default async function ExportManager(message: Discord.Message) {
 
 
     const member = message.member;
-    const moderator = !!member.roles.some(r=>r.name === MODERATOR_ROLE_NAME);
+    const moderator = !!member.roles.cache.some(r=>r.name === MODERATOR_ROLE_NAME);
     
     switch (toExportType) {
 
@@ -35,7 +35,7 @@ export default async function ExportManager(message: Discord.Message) {
 
 const exportRole = (toExport:string, guild:Guild, message: Discord.Message) => {
     // toExport = toExport.match()
-    const foundRole = guild.roles.find(role => role.name.toLowerCase() === toExport.toLowerCase())
+    const foundRole = guild.roles.cache.find(role => role.name.toLowerCase() === toExport.toLowerCase())
     if(!foundRole) {
         message.channel.send(`No roles found for "${toExport}". Export like !export role "study group french"`)
     }

--- a/src/programs/GroupManager.ts
+++ b/src/programs/GroupManager.ts
@@ -1,10 +1,12 @@
-import Discord, { Snowflake, TextChannel, GuildMember, Message, MessageEmbed } from 'discord.js';
+import Discord, { Snowflake, TextChannel, GuildMember, Message, MessageEmbed, MessageReaction, GuildMemberManager, User } from 'discord.js';
 import Tools from '../common/tools';
 import { MODERATOR_ROLE_NAME } from '../const';
+import { group } from 'console';
 
 interface DiscordGroup {
     name: String,
-    members: String[]
+    members: String[],
+    description: String,
 }
 
 let message: Message;
@@ -19,7 +21,8 @@ export default async function GroupManager(pMessage: Discord.Message, commandInd
 
         const words = Tools.stringToWords(pMessage.cleanContent)
         words.shift();
-        const [action, requestName] = words
+        const [action, requestName, ...descriptionWords] = words
+        const description = descriptionWords.join(" ");
 
         if (!action || !(["join", "create", "leave", "search", "delete"].includes(action))) {
             pMessage.reply(`Incorrect syntax, please use the following: \`!group join|leave|create|search|delete\``);
@@ -28,7 +31,7 @@ export default async function GroupManager(pMessage: Discord.Message, commandInd
 
         const groups = await <DiscordGroup[]><unknown>Tools.resolveFile("groupManager");
         const user = pMessage.member;
-        const moderator = !!pMessage.member.roles.cache.has(pMessage.guild.roles.cache.find(r=>r.name === MODERATOR_ROLE_NAME).id);
+        const moderator = !!pMessage.member.roles.cache.has(pMessage.guild.roles.cache.find(r => r.name === MODERATOR_ROLE_NAME).id);
 
         switch (action) {
 
@@ -38,7 +41,7 @@ export default async function GroupManager(pMessage: Discord.Message, commandInd
                 break;
 
             case "create":
-                if(moderator) createGroup(groups, requestName, user);
+                if (moderator) createGroup(groups, requestName, user, description);
                 else pMessage.reply("You do not have permission to use this command.")
                 break;
 
@@ -51,7 +54,7 @@ export default async function GroupManager(pMessage: Discord.Message, commandInd
 
                 break;
             case "delete":
-                if(moderator) deleteGroup(groups, requestName);
+                if (moderator) deleteGroup(groups, requestName);
                 else pMessage.reply("You do not have permission to use this command.")
                 break;
 
@@ -85,72 +88,121 @@ export default async function GroupManager(pMessage: Discord.Message, commandInd
 
 
 
-    }
-
-    const deleteGroup = (groups: DiscordGroup[], requestedGroupName: string = "") => {
-        
-        if(!requestedGroupName) {
-            message.react("👎")
-            return;
-        }
-            let exists = false;
-    
-            groups.forEach((group: DiscordGroup) => {
-                if (group.name.toLowerCase() == requestedGroupName.toLowerCase()) {
-                    group.members.forEach(async (member) => {
-                        let localUserData = await Tools.getUserData(<string>member)
-                        localUserData.groups.splice(localUserData.groups.indexOf(<string>group.name), 1)
-                        Tools.updateUserData(localUserData)
-                    })
-
-                    groups.splice(groups.indexOf(group), 1)
-                    exists = true;
-                }
-            })
-    
-            if (exists) {
-                Tools.writeFile("groupManager", groups);
-                message.react("👍")
-            }
-            else {
-                message.react("👎")
-            
-            }
-    }
-
-
-    const searchGroup = (groups: DiscordGroup[], requestedGroupName: string = "") => {
-
-        const searchEmbed = new MessageEmbed({
-        }).setAuthor("YesBot", "https://cdn.discordapp.com/avatars/614101602046836776/61d02233797a400bc0e360098e3fe9cb.png?size=$%7BrequestedImageSize%7D")
-        searchEmbed.setDescription(`Results for group "${requestedGroupName}"`)
-        groups = orderGroupsBy(groups)
-
-        groups.forEach((group: any) => {
-
-            if (group.name.includes() == requestedGroupName) {
-                searchEmbed.addField("Group Name:", group.name, true)
-                searchEmbed.addField("Number of Members:", group.members.length, true)
-                searchEmbed.addField('\u200b', '\u200b')
-            }
-        })
-
-
-        message.channel.send(searchEmbed)
-    }
-
-const orderGroupsBy = (object:Array<DiscordGroup>): DiscordGroup[] => {
-     return object;
 }
 
-const createGroup = async (groups: DiscordGroup[], requestedGroupName: string, member: GuildMember) => {
-    if(!requestedGroupName) {
+const deleteGroup = (groups: DiscordGroup[], requestedGroupName: string = "") => {
+
+    if (!requestedGroupName) {
+        message.react("👎")
+        return;
+    }
+    let exists = false;
+
+    groups.forEach((group: DiscordGroup) => {
+        if (group.name.toLowerCase() == requestedGroupName.toLowerCase()) {
+            group.members.forEach(async (member) => {
+                let localUserData = await Tools.getUserData(<string>member)
+                localUserData.groups.splice(localUserData.groups.indexOf(<string>group.name), 1)
+                Tools.updateUserData(localUserData)
+            })
+
+            groups.splice(groups.indexOf(group), 1)
+            exists = true;
+        }
+    })
+
+    if (exists) {
+        Tools.writeFile("groupManager", groups);
+        message.react("👍")
+    }
+    else {
+        message.react("👎")
+
+    }
+}
+
+
+const searchGroup = (groups: DiscordGroup[], requestedGroupName: string = "") => {
+    const groupsPerPage = 4;
+    const pages: Array<MessageEmbed> = [];
+    groups = orderGroupsBy(groups)
+
+    const groupFilter = ({ name }: DiscordGroup) => name.toLowerCase().includes(requestedGroupName.toLowerCase());
+    const byMemberCount = (a: DiscordGroup, b: DiscordGroup) => b.members.length - a.members.length;
+    const copy = Array.from(groups.filter(groupFilter)).sort(byMemberCount);
+    const pageAmount = Math.ceil(copy.length / groupsPerPage);
+
+    for (let i = 0; i < pageAmount; i++) {
+        const embed = new MessageEmbed({})
+            .setAuthor("YesBot", "https://cdn.discordapp.com/avatars/614101602046836776/61d02233797a400bc0e360098e3fe9cb.png?size=$%7BrequestedImageSize%7D");
+        embed.setDescription(`Results for group "${requestedGroupName}" (Page ${i + 1} / ${pageAmount})`);
+
+        const chunk = copy.splice(0, groupsPerPage);
+
+        chunk.forEach((group) => {
+            embed.addField("Group Name:", group.name, true);
+            embed.addField("Number of Members:", group.members.length, true);
+            embed.addField("Description", group.description || "-");
+            embed.addField("\u200B", "\u200B");
+        });
+
+        pages.push(embed);
+    }
+
+    const flip = async (page: number, shownPageMessage: Message, reaction: MessageReaction) => {
+        if (page < 0) page = 0;
+        if (page >= pages.length) page = pages.length - 1;
+
+        await shownPageMessage.edit(message.author.toString(), { embed: pages[page] });
+        await reaction.users.remove(message.author.id);
+        setupPaging(page, shownPageMessage);
+    }
+
+    const setupPaging = async (currentPage: number, pagedMessage: Message) => {
+        const filter = (reaction: MessageReaction, user: User) => {
+            return ["⬅️", "➡️"].includes(reaction.emoji.name) && user.id === message.author.id;
+        }
+
+        try {
+            const reactions = await pagedMessage.awaitReactions(filter, { max: 1, time: 60000, errors: ['time'] });
+            const first = reactions.first();
+            if (first.emoji.name === "⬅️") {
+                flip(currentPage - 1, pagedMessage, first);
+            }
+            if (first.emoji.name === "➡️") {
+                flip(currentPage + 1, pagedMessage, first);
+            }
+        } catch (error) {
+            if (error !== 'time')
+                console.log(JSON.stringify(error));
+            else
+                console.log("Knew it...");
+        }
+    }
+
+    const sentMessagePromise = message.channel.send(message.author.toString(), pages[0]);
+    if (pages.length > 1) {
+        sentMessagePromise.then(async msg => {
+            await msg.react("⬅️");
+            await msg.react("➡️");
+            return msg;
+        })
+            .then((msg) => setupPaging(0, msg));
+    }
+}
+
+const orderGroupsBy = (object: Array<DiscordGroup>): DiscordGroup[] => {
+    return object;
+}
+
+const createGroup = async (groups: DiscordGroup[], requestedGroupName: string, member: GuildMember, description: String) => {
+    if (!requestedGroupName) {
         message.react("👎")
         return;
     }
     let localUserData = await Tools.getUserData(member.user.id)
     let exists = false;
-    
+
     groups.forEach((group: any) => {
         if (group.name.toLowerCase() == requestedGroupName.toLowerCase()) {
             message.reply("That group already exists!")
@@ -167,7 +219,8 @@ const createGroup = async (groups: DiscordGroup[], requestedGroupName: string, m
             "name": requestedGroupName,
             "members": [
                 message.author.id
-            ]
+            ],
+            "description": description
         })
 
         Tools.writeFile("groupManager", groups);
@@ -178,51 +231,51 @@ const createGroup = async (groups: DiscordGroup[], requestedGroupName: string, m
 const joinGroup = async (groups: DiscordGroup[], requestedGroupName: string, member: GuildMember) => {
     let foundGroup = false;
     let localUserData = await Tools.getUserData(member.user.id)
-    
+
     groups.forEach((group: DiscordGroup) => {
         if (group.name.toLowerCase() === requestedGroupName.toLowerCase()) {
             foundGroup = true;
-            
+
             localUserData.groups.push(<string>group.name)
             Tools.updateUserData(localUserData)
-                    if (!group.members.includes(member.id)) {
-                        group.members.push(member.id)
-                        Tools.writeFile("groupManager", groups)
-                        message.react("👍")
-                    }
-                    else {
-                        message.react("👎")
-                        message.reply("You are already in that group!")
-                    }
-                }
-            })
-        if (!foundGroup) {
-            message.reply("I couldn't find that group.")
+            if (!group.members.includes(member.id)) {
+                group.members.push(member.id)
+                Tools.writeFile("groupManager", groups)
+                message.react("👍")
+            }
+            else {
+                message.react("👎")
+                message.reply("You are already in that group!")
+            }
         }
+    })
+    if (!foundGroup) {
+        message.reply("I couldn't find that group.")
     }
+}
 
 const leaveGroup = async (groups: DiscordGroup[], requestedGroupName: string, member: GuildMember) => {
     let localUserData = await Tools.getUserData(member.user.id)
-            let success: boolean = false;
-            groups.forEach((group: DiscordGroup) => {
-                if (group.name.toLowerCase() === requestedGroupName.toLowerCase()) {
-                    localUserData.groups.splice(localUserData.groups.indexOf(<string>group.name), 1)
-                    Tools.updateUserData(localUserData)
-                    const groupPosition = group.members.indexOf(member.id)
+    let success: boolean = false;
+    groups.forEach((group: DiscordGroup) => {
+        if (group.name.toLowerCase() === requestedGroupName.toLowerCase()) {
+            localUserData.groups.splice(localUserData.groups.indexOf(<string>group.name), 1)
+            Tools.updateUserData(localUserData)
+            const groupPosition = group.members.indexOf(member.id)
 
-                    if (groupPosition > -1) {
-
-
-                        group.members.splice(groupPosition, 1)
+            if (groupPosition > -1) {
 
 
-                        Tools.writeFile("groupManager", groups)
-                        success = true;
-                    }
-                }
-            })
-            message.react(success ? "👍" : "👎");
-            if (!success) message.reply("You are not in that group!")
+                group.members.splice(groupPosition, 1)
+
+
+                Tools.writeFile("groupManager", groups)
+                success = true;
+            }
         }
+    })
+    message.react(success ? "👍" : "👎");
+    if (!success) message.reply("You are not in that group!")
+}
 
 

--- a/src/programs/GroupManager.ts
+++ b/src/programs/GroupManager.ts
@@ -28,7 +28,7 @@ export default async function GroupManager(pMessage: Discord.Message, commandInd
 
         const groups = await <DiscordGroup[]><unknown>Tools.resolveFile("groupManager");
         const user = pMessage.member;
-        const moderator = !!pMessage.member.roles.has(pMessage.guild.roles.find(r=>r.name === MODERATOR_ROLE_NAME).id);
+        const moderator = !!pMessage.member.roles.cache.has(pMessage.guild.roles.cache.find(r=>r.name === MODERATOR_ROLE_NAME).id);
 
         switch (action) {
 
@@ -131,7 +131,7 @@ export default async function GroupManager(pMessage: Discord.Message, commandInd
             if (group.name.includes() == requestedGroupName) {
                 searchEmbed.addField("Group Name:", group.name, true)
                 searchEmbed.addField("Number of Members:", group.members.length, true)
-                searchEmbed.addBlankField()
+                searchEmbed.addField('\u200b', '\u200b')
             }
         })
 

--- a/src/programs/InitialiseTestEnvironment.ts
+++ b/src/programs/InitialiseTestEnvironment.ts
@@ -3,7 +3,7 @@ import Tools from '../common/tools';
 
 
 export default async function InitialiseTestEnvironment(bot: Client) {
-    const testGuild = bot.guilds.find(g => g.name == "Test Theory Fam");
-    const testChat = <TextChannel>testGuild.channels.find(c => c.name == "chat");
+    const testGuild = bot.guilds.cache.find(g => g.name == "Test Theory Fam");
+    const testChat = <TextChannel>testGuild.channels.cache.find(c => c.name == "chat");
     testGuild.channels.create("Role-picker")
 }

--- a/src/programs/ProfileManager.ts
+++ b/src/programs/ProfileManager.ts
@@ -22,7 +22,7 @@ export default async function ProfileManager(pMessage: Discord.Message, commandI
         
         let requestedUser = pMessage.mentions.users.first()
         if(!requestedUser) requestedUser = pMessage.member.user;
-        const requestedMember = pMessage.guild.members.find(m => m.user === requestedUser)
+        const requestedMember = pMessage.guild.members.cache.find(m => m.user === requestedUser)
 
         if(!requestedMember) {
             pMessage.reply("I couldn't find that member in this server!");
@@ -41,15 +41,15 @@ interface Birthday {
 
 const getProfileEmbed = async (member:GuildMember, message: Message): Promise<MessageEmbed> => {
     const profileEmbed = new MessageEmbed();
-    const countryRole = member.roles.find(r => r.name.includes("I'm from"))
+    const countryRole = member.roles.cache.find(r => r.name.includes("I'm from"))
     let countryString = ''
-    member.roles.forEach(role => {
+    member.roles.cache.forEach(role => {
         
         if(role.name.includes("I'm from")) {
             countryString = countryString + role.name + "\n";
         }
     })
-    const yesEmoji = member.guild.emojis.find(e => e.name == "yes_yf")
+    const yesEmoji = member.guild.emojis.cache.find(e => e.name == "yes_yf")
     const birthdays:Birthday[] = <Birthday[]><unknown>await Tools.resolveFile("birthdayMembers");
     let birthdayString = 'Unknown'
     birthdays.forEach((birthday:Birthday) => {
@@ -81,7 +81,7 @@ const getProfileEmbed = async (member:GuildMember, message: Message): Promise<Me
     profileEmbed.setColor(member.roles.color.color)
     profileEmbed.addField("Hi! My name is:", member.displayName, true)
     profileEmbed.addField("Where I'm from:", countryString, true)
-    profileEmbed.addBlankField()
+    profileEmbed.addField('\u200b', '\u200b')
     profileEmbed.addField("Joined on:", joinDate, true);
     profileEmbed.addField("Birthday:", birthdayString, true);
     profileEmbed.addField("Groups:", groupString || "None", true);

--- a/src/programs/ReactRole.ts
+++ b/src/programs/ReactRole.ts
@@ -7,7 +7,7 @@ export default async function ReactRole(pMessage: Discord.Message) {
 
     //! This comes to us in the format of "!roles [add|list] [messageId] [emoji] [roleId] [channelId]"
     //! So first we need to establish if it is add or list
-    const isSupport = pMessage.member.roles.has(pMessage.guild.roles.find(r => r.name == MODERATOR_ROLE_NAME).id)
+    const isSupport = pMessage.member.roles.cache.has(pMessage.guild.roles.cache.find(r => r.name == MODERATOR_ROLE_NAME).id)
     if(!isSupport) return;
 
     const args = <string[]>pMessage.content.split(" ");
@@ -56,7 +56,7 @@ async function addReactRoleObject(messageId: Snowflake, reaction: string, roleId
             const successEmbed = new Discord.MessageEmbed()
                 .setColor('#ff6063')
                 .setTitle('Reaction role successfully added.')
-                .addBlankField()
+                .addField('\u200b', '\u200b')
                 .addField('Target Message:', message.cleanContent, true)
                 .addField('Target Channel:', channel, true)
                 .addField('Necessary Reaction:', reaction, true)
@@ -81,7 +81,7 @@ async function listReactRoleObjects(pMessage: Discord.Message) {
     let returnString = "**List of available role reactions**:\n\n";
     try {
         await Promise.all(reactRoleObjects.map(async (i: any) => {
-            let role = guild.roles.find(r => r.id == i.roleId);
+            let role = guild.roles.cache.find(r => r.id == i.roleId);
             let [message, channel] = await Tools.getMessageById(i.messageId, guild, i.channelId)
             message = <Discord.Message>message;
             returnString += `__**${index}:**__\n**Message**: ${message.cleanContent}\n`

--- a/src/programs/Someone.ts
+++ b/src/programs/Someone.ts
@@ -18,7 +18,7 @@ async function Someone(message: Discord.Message) {
         return;
     }
 
-    const hasSeekDiscomfort = message.member.roles.has(message.guild.roles.find(r => r.name == "Seek Discomfort").id);
+    const hasSeekDiscomfort = message.member.roles.cache.has(message.guild.roles.cache.find(r => r.name == "Seek Discomfort").id);
     
     if(!hasSeekDiscomfort) {
         const deniedMessage = await message.reply("You need the Seek Discomfort role for that! You can get one by writing a detailed bio of yourself in <#616616321089798145>.")
@@ -79,7 +79,7 @@ async function isAllowed(user:Discord.User) {
 
 async function getTarget(arg: string, message: Discord.Message) {
     if(message) {
-        const sdRole = message.guild.roles.find(r => r.name == "Seek Discomfort");
+        const sdRole = message.guild.roles.cache.find(r => r.name == "Seek Discomfort");
         if(!sdRole) {
             message.channel.send("There is no Seek Discomfort role in this server!");
             return;

--- a/src/programs/StateRoleFinder.ts
+++ b/src/programs/StateRoleFinder.ts
@@ -16,8 +16,8 @@ export default async function StateRoleFinder(pMessage: Discord.Message) {
     }
     const stateRoles = await Tools.resolveFile("stateRoles");
     let found = false;
-    let supportRole = pMessage.guild.roles.find(r => r.name == MODERATOR_ROLE_NAME)
-    if (pMessage.member.roles.has(supportRole.id)) {
+    let supportRole = pMessage.guild.roles.cache.find(r => r.name == MODERATOR_ROLE_NAME)
+    if (pMessage.member.roles.cache.has(supportRole.id)) {
         stateRoles.forEach((stateRole: any) => {
             const { state, role } = stateRole;
                 if (state.toLowerCase() === stateRequest.toLowerCase()) {

--- a/src/programs/Ticket.ts
+++ b/src/programs/Ticket.ts
@@ -46,7 +46,7 @@ export default async function Ticket(pMessage: Discord.Message, type:string) {
         break;
     }
 
-    const moderatorRole = pMessage.guild.roles.find(r => r.name == moderatorRoleName)
+    const moderatorRole = pMessage.guild.roles.cache.find(r => r.name == moderatorRoleName)
 
     //! This comes to us in the format of "![fiyesta|shoutout] [close|logs]?"
     const args = pMessage.cleanContent.split(" ")
@@ -57,12 +57,12 @@ export default async function Ticket(pMessage: Discord.Message, type:string) {
     const isForceClose = pMessage.cleanContent.split(" ")[1] == "forceclose";
     
     const isClose = pMessage.cleanContent.split(" ")[1] == "close";
-    const supportRole = pMessage.guild.roles.find(r => r.name == moderatorRoleName);
+    const supportRole = pMessage.guild.roles.cache.find(r => r.name == moderatorRoleName);
 
     if (isClose) {
         const ticketChannel = <Discord.TextChannel>pMessage.channel;
         if (ticketChannel.name.startsWith(type)) {
-            if (pMessage.member.roles.has(supportRole.id)) createCloseMessage(ticketChannel, pMessage.author, TICKET_LOG_CHANNEL)
+            if (pMessage.member.roles.cache.has(supportRole.id)) createCloseMessage(ticketChannel, pMessage.author, TICKET_LOG_CHANNEL)
         }
         return;
     }
@@ -70,7 +70,7 @@ export default async function Ticket(pMessage: Discord.Message, type:string) {
     if(isForceClose){
         const ticketChannel = <Discord.TextChannel>pMessage.channel;
         if(ticketChannel.name.startsWith(type)) {
-            if(pMessage.member.roles.has(supportRole.id)) closeTicket(ticketChannel, pMessage.author, TICKET_LOG_CHANNEL)
+            if(pMessage.member.roles.cache.has(supportRole.id)) closeTicket(ticketChannel, pMessage.author, TICKET_LOG_CHANNEL)
         }
     }
 
@@ -103,7 +103,7 @@ export default async function Ticket(pMessage: Discord.Message, type:string) {
             parent:categoryId
         }
         channelName = channelName.replace(/\s+/g, '-').toLowerCase();
-        if(pMessage.guild.channels.find(c => c.name == channelName)) {
+        if(pMessage.guild.channels.cache.find(c => c.name == channelName)) {
             pMessage.author.createDM().then(channel => {
                 channel.send("You already have a ticket open, please close that one first before opening another.")
             })
@@ -126,7 +126,7 @@ export default async function Ticket(pMessage: Discord.Message, type:string) {
 async function closeTicket(c: Discord.TextChannel, m: Discord.User,lc:string) {
 
     const text = await createOutput(c,m);
-    const logChannel = <TextChannel>c.guild.channels.find(c => c.name.startsWith(lc))
+    const logChannel = <TextChannel>c.guild.channels.cache.find(c => c.name.startsWith(lc))
     logChannel.send(text, {split:true})
     c.delete("Closed Ticket");
 }
@@ -159,7 +159,7 @@ async function createCloseMessage(c: TextChannel, m: User, TICKET_LOG_CHANNEL:st
     }, { max: 1, time: 60000, errors: ['time'] })
         .then(collected => {
             const reaction = collected.first();
-            const user = reaction.users.array()[1];
+            const user = reaction.users.cache.array()[1];
 
             if (reaction.emoji.name === '✅') {
                 message.reply('you reacted with a ✅ up.');

--- a/src/programs/Unassigned.ts
+++ b/src/programs/Unassigned.ts
@@ -4,24 +4,24 @@ import { MODERATOR_ROLE_NAME } from '../const';
 export default function Unassigned(message: Discord.Message) {
     const guild = message.guild;
 
-    const UnassignedRole = guild.roles.find(role => role.name === "Unassigned");
+    const UnassignedRole = guild.roles.cache.find(role => role.name === "Unassigned");
 
-    const authorIsSupport = message.guild.member(message.author).roles.some(role => role.name === MODERATOR_ROLE_NAME);
+    const authorIsSupport = message.guild.member(message.author).roles.cache.some(role => role.name === MODERATOR_ROLE_NAME);
     if (!authorIsSupport)
         return;
 
     const isInModSection = (message.channel as TextChannel).name === "permanent-testing";
     if (!isInModSection)
         return;
-    const missedUsers = guild.members.filter((member) => member.roles.size === 1);
+    const missedUsers = guild.members.cache.filter((member) => member.roles.cache.size === 1);
 
     missedUsers.forEach(member => member.roles.add(UnassignedRole));
 
     message.channel.send(`Added Unassigned role to ${missedUsers.size} members of the server!`);
 
-    const whoopsUsers = guild.members
-        .filter(member => member.roles.some(role => role.id === UnassignedRole.id))
-        .filter(member => member.roles.size > 2); // @everyone + Unassigned + at least another role.
+    const whoopsUsers = guild.members.cache
+        .filter(member => member.roles.cache.some(role => role.id === UnassignedRole.id))
+        .filter(member => member.roles.cache.size > 2); // @everyone + Unassigned + at least another role.
     whoopsUsers.forEach(member => member.roles.remove(UnassignedRole));
     message.channel.send(`Removed Unassigned role from ${whoopsUsers.size} members of the server!`);
 }

--- a/src/programs/WhereAreYouFromManager.ts
+++ b/src/programs/WhereAreYouFromManager.ts
@@ -10,7 +10,7 @@ interface Country {
 
 export default async function WhereAreYouFromManager(pMessage: Discord.Message) {
 
-    const hasRoles = !!pMessage.member.roles.find(role => role.name.includes("I'm from"));
+    const hasRoles = !!pMessage.member.roles.cache.find(role => role.name.includes("I'm from"));
     const {guild, channel} = pMessage;
     const countries: Array<Object> = await Tools.resolveFile("countryRoles");
     const words: Array<string> = pMessage.cleanContent.split(" ");
@@ -18,7 +18,7 @@ export default async function WhereAreYouFromManager(pMessage: Discord.Message) 
     words.forEach(word => {
         countries.forEach((country: any) => {
             if (word.toLowerCase() === country.name.toLowerCase()) {
-                const roleToGive = pMessage.guild.roles.find(role => role.name.toLowerCase().includes(word.toLowerCase()));
+                const roleToGive = pMessage.guild.roles.cache.find(role => role.name.toLowerCase().includes(word.toLowerCase()));
                 if (roleToGive) {
                     const flagReaction: string = flag(country.code)
                     if (!hasRoles) {
@@ -29,8 +29,8 @@ export default async function WhereAreYouFromManager(pMessage: Discord.Message) 
                             return (flagReaction.includes(reaction.emoji.name) && !user.bot);
                         },{ 
                             max: 1, time: 60000000, errors: ['time'] }).then(collected => {
-                                const user = pMessage.guild.members.find(member => {
-                                    return !!member.roles.find(role => role.name == "Support")
+                                const user = pMessage.guild.members.cache.find(member => {
+                                    return !!member.roles.cache.find(role => role.name == "Support")
                                 });
                                 if (user) pMessage.member.roles.add(roleToGive);
                             })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -62,5 +62,13 @@
 
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
-  }
+  },
+  "include": [
+    "./index.d.ts",
+    "./src",
+  ],
+  "exclude": [
+    "node_modules",
+    "build"
+  ]
 }


### PR DESCRIPTION
Changed dependency discord.js from master to ^12.0.0
Updated tsconfig with include and exclude fields
Installed `@types/ws` for one TS error
Changed `.addBlankField()` to `.addField('\u200b', '\u200b')` (see https://discordjs.guide/popular-topics/embeds.html#using-the-richembedmessageembed-constructor)
Resolved all TS errors coming from the change to Managers from discord.js 11 to 12
Added index.d.ts to add typings for country-code-emoji
Ran `npm upgrade` to get all the fresh goodness (including TS 3.8)

--------------

`!group search` now displays a new form of embeds showing 4 groups and their descriptions at a time
Parameter to `!group search` is used to filter groups
Groups are ordered by member count (descending)
Embeds are sent with two reactions that can be used to flip through the pages of available groups in case the results to the query are more than 4
`!group create` will use all arguments after the group name as description