### PR TITLE
Release/buddyproject

### DIFF
--- a/src/collections/flagEmojis.ts
+++ b/src/collections/flagEmojis.ts
@@ -1,0 +1,1930 @@
+export interface Country {
+  code: string,
+  emoji: string,
+  unicode: string,
+  name: string,
+  title: string
+}
+
+
+export const countries: Country[] = [
+  {
+    "code": "AD",
+    "emoji": "🇦🇩",
+    "unicode": "U+1F1E6 U+1F1E9",
+    "name": "Andorra",
+    "title": "flag for Andorra",
+
+  },
+  {
+    "code": "AE",
+    "emoji": "🇦🇪",
+    "unicode": "U+1F1E6 U+1F1EA",
+    "name": "United Arab Emirates",
+    "title": "flag for United Arab Emirates",
+
+  },
+  {
+    "code": "AF",
+    "emoji": "🇦🇫",
+    "unicode": "U+1F1E6 U+1F1EB",
+    "name": "Afghanistan",
+    "title": "flag for Afghanistan",
+  },
+  {
+    "code": "AG",
+    "emoji": "🇦🇬",
+    "unicode": "U+1F1E6 U+1F1EC",
+    "name": "Antigua and Barbuda",
+    "title": "flag for Antigua and Barbuda",
+  },
+  {
+    "code": "AI",
+    "emoji": "🇦🇮",
+    "unicode": "U+1F1E6 U+1F1EE",
+    "name": "Anguilla",
+    "title": "flag for Anguilla",
+  },
+  {
+    "code": "AL",
+    "emoji": "🇦🇱",
+    "unicode": "U+1F1E6 U+1F1F1",
+    "name": "Albania",
+    "title": "flag for Albania",
+
+  },
+  {
+    "code": "AM",
+    "emoji": "🇦🇲",
+    "unicode": "U+1F1E6 U+1F1F2",
+    "name": "Armenia",
+    "title": "flag for Armenia",
+
+  },
+  {
+    "code": "AO",
+    "emoji": "🇦🇴",
+    "unicode": "U+1F1E6 U+1F1F4",
+    "name": "Angola",
+    "title": "flag for Angola",
+
+  },
+  {
+    "code": "AQ",
+    "emoji": "🇦🇶",
+    "unicode": "U+1F1E6 U+1F1F6",
+    "name": "Antarctica",
+    "title": "flag for Antarctica",
+  },
+  {
+    "code": "AR",
+    "emoji": "🇦🇷",
+    "unicode": "U+1F1E6 U+1F1F7",
+    "name": "Argentina",
+    "title": "flag for Argentina",
+  },
+  {
+    "code": "AS",
+    "emoji": "🇦🇸",
+    "unicode": "U+1F1E6 U+1F1F8",
+    "name": "American Samoa",
+    "title": "flag for American Samoa",
+  },
+  {
+    "code": "AT",
+    "emoji": "🇦🇹",
+    "unicode": "U+1F1E6 U+1F1F9",
+    "name": "Austria",
+    "title": "flag for Austria",
+  },
+  {
+    "code": "AU",
+    "emoji": "🇦🇺",
+    "unicode": "U+1F1E6 U+1F1FA",
+    "name": "Australia",
+    "title": "flag for Australia",
+  },
+  {
+    "code": "AW",
+    "emoji": "🇦🇼",
+    "unicode": "U+1F1E6 U+1F1FC",
+    "name": "Aruba",
+    "title": "flag for Aruba",
+
+  },
+  {
+    "code": "AX",
+    "emoji": "🇦🇽",
+    "unicode": "U+1F1E6 U+1F1FD",
+    "name": "Åland Islands",
+    "title": "flag for Åland Islands"
+  },
+  {
+    "code": "AZ",
+    "emoji": "🇦🇿",
+    "unicode": "U+1F1E6 U+1F1FF",
+    "name": "Azerbaijan",
+    "title": "flag for Azerbaijan",
+
+  },
+  {
+    "code": "BA",
+    "emoji": "🇧🇦",
+    "unicode": "U+1F1E7 U+1F1E6",
+    "name": "Bosnia and Herzegovina",
+    "title": "flag for Bosnia and Herzegovina",
+
+  },
+  {
+    "code": "BB",
+    "emoji": "🇧🇧",
+    "unicode": "U+1F1E7 U+1F1E7",
+    "name": "Barbados",
+    "title": "flag for Barbados",
+  },
+  {
+    "code": "BD",
+    "emoji": "🇧🇩",
+    "unicode": "U+1F1E7 U+1F1E9",
+    "name": "Bangladesh",
+    "title": "flag for Bangladesh",
+
+  },
+  {
+    "code": "BE",
+    "emoji": "🇧🇪",
+    "unicode": "U+1F1E7 U+1F1EA",
+    "name": "Belgium",
+    "title": "flag for Belgium",
+  },
+  {
+    "code": "BF",
+    "emoji": "🇧🇫",
+    "unicode": "U+1F1E7 U+1F1EB",
+    "name": "Burkina Faso",
+    "title": "flag for Burkina Faso",
+
+  },
+  {
+    "code": "BG",
+    "emoji": "🇧🇬",
+    "unicode": "U+1F1E7 U+1F1EC",
+    "name": "Bulgaria",
+    "title": "flag for Bulgaria",
+
+  },
+  {
+    "code": "BH",
+    "emoji": "🇧🇭",
+    "unicode": "U+1F1E7 U+1F1ED",
+    "name": "Bahrain",
+    "title": "flag for Bahrain",
+
+  },
+  {
+    "code": "BI",
+    "emoji": "🇧🇮",
+    "unicode": "U+1F1E7 U+1F1EE",
+    "name": "Burundi",
+    "title": "flag for Burundi",
+
+  },
+  {
+    "code": "BJ",
+    "emoji": "🇧🇯",
+    "unicode": "U+1F1E7 U+1F1EF",
+    "name": "Benin",
+    "title": "flag for Benin",
+
+  },
+  {
+    "code": "BL",
+    "emoji": "🇧🇱",
+    "unicode": "U+1F1E7 U+1F1F1",
+    "name": "Saint Barthélemy",
+    "title": "flag for Saint Barthélemy",
+
+  },
+  {
+    "code": "BM",
+    "emoji": "🇧🇲",
+    "unicode": "U+1F1E7 U+1F1F2",
+    "name": "Bermuda",
+    "title": "flag for Bermuda",
+  },
+  {
+    "code": "BN",
+    "emoji": "🇧🇳",
+    "unicode": "U+1F1E7 U+1F1F3",
+    "name": "Brunei Darussalam",
+    "title": "flag for Brunei Darussalam",
+
+  },
+  {
+    "code": "BO",
+    "emoji": "🇧🇴",
+    "unicode": "U+1F1E7 U+1F1F4",
+    "name": "Bolivia",
+    "title": "flag for Bolivia",
+
+  },
+  {
+    "code": "BQ",
+    "emoji": "🇧🇶",
+    "unicode": "U+1F1E7 U+1F1F6",
+    "name": "Bonaire, Sint Eustatius and Saba",
+    "title": "flag for Bonaire, Sint Eustatius and Saba"
+  },
+  {
+    "code": "BR",
+    "emoji": "🇧🇷",
+    "unicode": "U+1F1E7 U+1F1F7",
+    "name": "Brazil",
+    "title": "flag for Brazil",
+  },
+  {
+    "code": "BS",
+    "emoji": "🇧🇸",
+    "unicode": "U+1F1E7 U+1F1F8",
+    "name": "Bahamas",
+    "title": "flag for Bahamas",
+  },
+  {
+    "code": "BT",
+    "emoji": "🇧🇹",
+    "unicode": "U+1F1E7 U+1F1F9",
+    "name": "Bhutan",
+    "title": "flag for Bhutan",
+
+  },
+  {
+    "code": "BV",
+    "emoji": "🇧🇻",
+    "unicode": "U+1F1E7 U+1F1FB",
+    "name": "Bouvet Island",
+    "title": "flag for Bouvet Island"
+  },
+  {
+    "code": "BW",
+    "emoji": "🇧🇼",
+    "unicode": "U+1F1E7 U+1F1FC",
+    "name": "Botswana",
+    "title": "flag for Botswana",
+
+  },
+  {
+    "code": "BY",
+    "emoji": "🇧🇾",
+    "unicode": "U+1F1E7 U+1F1FE",
+    "name": "Belarus",
+    "title": "flag for Belarus",
+
+  },
+  {
+    "code": "BZ",
+    "emoji": "🇧🇿",
+    "unicode": "U+1F1E7 U+1F1FF",
+    "name": "Belize",
+    "title": "flag for Belize",
+
+  },
+  {
+    "code": "CA",
+    "emoji": "🇨🇦",
+    "unicode": "U+1F1E8 U+1F1E6",
+    "name": "Canada",
+    "title": "flag for Canada",
+  },
+  {
+    "code": "CC",
+    "emoji": "🇨🇨",
+    "unicode": "U+1F1E8 U+1F1E8",
+    "name": "Cocos (Keeling) Islands",
+    "title": "flag for Cocos (Keeling) Islands",
+  },
+  {
+    "code": "CD",
+    "emoji": "🇨🇩",
+    "unicode": "U+1F1E8 U+1F1E9",
+    "name": "Congo",
+    "title": "flag for Congo",
+
+  },
+  {
+    "code": "CF",
+    "emoji": "🇨🇫",
+    "unicode": "U+1F1E8 U+1F1EB",
+    "name": "Central African Republic",
+    "title": "flag for Central African Republic",
+
+  },
+  {
+    "code": "CG",
+    "emoji": "🇨🇬",
+    "unicode": "U+1F1E8 U+1F1EC",
+    "name": "Congo",
+    "title": "flag for Congo",
+
+  },
+  {
+    "code": "CH",
+    "emoji": "🇨🇭",
+    "unicode": "U+1F1E8 U+1F1ED",
+    "name": "Switzerland",
+    "title": "flag for Switzerland",
+  },
+  {
+    "code": "CI",
+    "emoji": "🇨🇮",
+    "unicode": "U+1F1E8 U+1F1EE",
+    "name": "Côte D'Ivoire",
+    "title": "flag for Côte D'Ivoire",
+
+  },
+  {
+    "code": "CK",
+    "emoji": "🇨🇰",
+    "unicode": "U+1F1E8 U+1F1F0",
+    "name": "Cook Islands",
+    "title": "flag for Cook Islands",
+
+  },
+  {
+    "code": "CL",
+    "emoji": "🇨🇱",
+    "unicode": "U+1F1E8 U+1F1F1",
+    "name": "Chile",
+    "title": "flag for Chile",
+  },
+  {
+    "code": "CM",
+    "emoji": "🇨🇲",
+    "unicode": "U+1F1E8 U+1F1F2",
+    "name": "Cameroon",
+    "title": "flag for Cameroon",
+
+  },
+  {
+    "code": "CN",
+    "emoji": "🇨🇳",
+    "unicode": "U+1F1E8 U+1F1F3",
+    "name": "China",
+    "title": "flag for China",
+  },
+  {
+    "code": "CO",
+    "emoji": "🇨🇴",
+    "unicode": "U+1F1E8 U+1F1F4",
+    "name": "Colombia",
+    "title": "flag for Colombia",
+  },
+  {
+    "code": "CR",
+    "emoji": "🇨🇷",
+    "unicode": "U+1F1E8 U+1F1F7",
+    "name": "Costa Rica",
+    "title": "flag for Costa Rica",
+
+  },
+  {
+    "code": "CU",
+    "emoji": "🇨🇺",
+    "unicode": "U+1F1E8 U+1F1FA",
+    "name": "Cuba",
+    "title": "flag for Cuba",
+  },
+  {
+    "code": "CV",
+    "emoji": "🇨🇻",
+    "unicode": "U+1F1E8 U+1F1FB",
+    "name": "Cape Verde",
+    "title": "flag for Cape Verde",
+
+  },
+  {
+    "code": "CW",
+    "emoji": "🇨🇼",
+    "unicode": "U+1F1E8 U+1F1FC",
+    "name": "Curaçao",
+    "title": "flag for Curaçao"
+  },
+  {
+    "code": "CX",
+    "emoji": "🇨🇽",
+    "unicode": "U+1F1E8 U+1F1FD",
+    "name": "Christmas Island",
+    "title": "flag for Christmas Island",
+  },
+  {
+    "code": "CY",
+    "emoji": "🇨🇾",
+    "unicode": "U+1F1E8 U+1F1FE",
+    "name": "Cyprus",
+    "title": "flag for Cyprus",
+
+  },
+  {
+    "code": "CZ",
+    "emoji": "🇨🇿",
+    "unicode": "U+1F1E8 U+1F1FF",
+    "name": "Czech Republic",
+    "title": "flag for Czech Republic",
+
+  },
+  {
+    "code": "DE",
+    "emoji": "🇩🇪",
+    "unicode": "U+1F1E9 U+1F1EA",
+    "name": "Germany",
+    "title": "flag for Germany",
+  },
+  {
+    "code": "DJ",
+    "emoji": "🇩🇯",
+    "unicode": "U+1F1E9 U+1F1EF",
+    "name": "Djibouti",
+    "title": "flag for Djibouti",
+
+  },
+  {
+    "code": "DK",
+    "emoji": "🇩🇰",
+    "unicode": "U+1F1E9 U+1F1F0",
+    "name": "Denmark",
+    "title": "flag for Denmark",
+  },
+  {
+    "code": "DM",
+    "emoji": "🇩🇲",
+    "unicode": "U+1F1E9 U+1F1F2",
+    "name": "Dominica",
+    "title": "flag for Dominica",
+  },
+  {
+    "code": "DO",
+    "emoji": "🇩🇴",
+    "unicode": "U+1F1E9 U+1F1F4",
+    "name": "Dominican Republic",
+    "title": "flag for Dominican Republic",
+  },
+  {
+    "code": "DZ",
+    "emoji": "🇩🇿",
+    "unicode": "U+1F1E9 U+1F1FF",
+    "name": "Algeria",
+    "title": "flag for Algeria",
+
+  },
+  {
+    "code": "EC",
+    "emoji": "🇪🇨",
+    "unicode": "U+1F1EA U+1F1E8",
+    "name": "Ecuador",
+    "title": "flag for Ecuador",
+
+  },
+  {
+    "code": "EE",
+    "emoji": "🇪🇪",
+    "unicode": "U+1F1EA U+1F1EA",
+    "name": "Estonia",
+    "title": "flag for Estonia",
+
+  },
+  {
+    "code": "EG",
+    "emoji": "🇪🇬",
+    "unicode": "U+1F1EA U+1F1EC",
+    "name": "Egypt",
+    "title": "flag for Egypt",
+  },
+  {
+    "code": "EH",
+    "emoji": "🇪🇭",
+    "unicode": "U+1F1EA U+1F1ED",
+    "name": "Western Sahara",
+    "title": "flag for Western Sahara"
+  },
+  {
+    "code": "ER",
+    "emoji": "🇪🇷",
+    "unicode": "U+1F1EA U+1F1F7",
+    "name": "Eritrea",
+    "title": "flag for Eritrea",
+
+  },
+  {
+    "code": "ES",
+    "emoji": "🇪🇸",
+    "unicode": "U+1F1EA U+1F1F8",
+    "name": "Spain",
+    "title": "flag for Spain",
+  },
+  {
+    "code": "ET",
+    "emoji": "🇪🇹",
+    "unicode": "U+1F1EA U+1F1F9",
+    "name": "Ethiopia",
+    "title": "flag for Ethiopia",
+
+  },
+  {
+    "code": "EU",
+    "emoji": "🇪🇺",
+    "unicode": "U+1F1EA U+1F1FA",
+    "name": "European Union",
+    "title": "flag for European Union"
+  },
+  {
+    "code": "FI",
+    "emoji": "🇫🇮",
+    "unicode": "U+1F1EB U+1F1EE",
+    "name": "Finland",
+    "title": "flag for Finland",
+
+  },
+  {
+    "code": "FJ",
+    "emoji": "🇫🇯",
+    "unicode": "U+1F1EB U+1F1EF",
+    "name": "Fiji",
+    "title": "flag for Fiji",
+
+  },
+  {
+    "code": "FK",
+    "emoji": "🇫🇰",
+    "unicode": "U+1F1EB U+1F1F0",
+    "name": "Falkland Islands (Malvinas)",
+    "title": "flag for Falkland Islands (Malvinas)",
+
+  },
+  {
+    "code": "FM",
+    "emoji": "🇫🇲",
+    "unicode": "U+1F1EB U+1F1F2",
+    "name": "Micronesia",
+    "title": "flag for Micronesia",
+
+  },
+  {
+    "code": "FO",
+    "emoji": "🇫🇴",
+    "unicode": "U+1F1EB U+1F1F4",
+    "name": "Faroe Islands",
+    "title": "flag for Faroe Islands",
+
+  },
+  {
+    "code": "FR",
+    "emoji": "🇫🇷",
+    "unicode": "U+1F1EB U+1F1F7",
+    "name": "France",
+    "title": "flag for France",
+  },
+  {
+    "code": "GA",
+    "emoji": "🇬🇦",
+    "unicode": "U+1F1EC U+1F1E6",
+    "name": "Gabon",
+    "title": "flag for Gabon",
+
+  },
+  {
+    "code": "GB",
+    "emoji": "🇬🇧",
+    "unicode": "U+1F1EC U+1F1E7",
+    "name": "United Kingdom",
+    "title": "flag for United Kingdom",
+  },
+  {
+    "code": "GD",
+    "emoji": "🇬🇩",
+    "unicode": "U+1F1EC U+1F1E9",
+    "name": "Grenada",
+    "title": "flag for Grenada",
+  },
+  {
+    "code": "GE",
+    "emoji": "🇬🇪",
+    "unicode": "U+1F1EC U+1F1EA",
+    "name": "Georgia",
+    "title": "flag for Georgia",
+
+  },
+  {
+    "code": "GF",
+    "emoji": "🇬🇫",
+    "unicode": "U+1F1EC U+1F1EB",
+    "name": "French Guiana",
+    "title": "flag for French Guiana",
+
+  },
+  {
+    "code": "GG",
+    "emoji": "🇬🇬",
+    "unicode": "U+1F1EC U+1F1EC",
+    "name": "Guernsey",
+    "title": "flag for Guernsey",
+  },
+  {
+    "code": "GH",
+    "emoji": "🇬🇭",
+    "unicode": "U+1F1EC U+1F1ED",
+    "name": "Ghana",
+    "title": "flag for Ghana",
+
+  },
+  {
+    "code": "GI",
+    "emoji": "🇬🇮",
+    "unicode": "U+1F1EC U+1F1EE",
+    "name": "Gibraltar",
+    "title": "flag for Gibraltar",
+
+  },
+  {
+    "code": "GL",
+    "emoji": "🇬🇱",
+    "unicode": "U+1F1EC U+1F1F1",
+    "name": "Greenland",
+    "title": "flag for Greenland",
+
+  },
+  {
+    "code": "GM",
+    "emoji": "🇬🇲",
+    "unicode": "U+1F1EC U+1F1F2",
+    "name": "Gambia",
+    "title": "flag for Gambia",
+
+  },
+  {
+    "code": "GN",
+    "emoji": "🇬🇳",
+    "unicode": "U+1F1EC U+1F1F3",
+    "name": "Guinea",
+    "title": "flag for Guinea",
+
+  },
+  {
+    "code": "GP",
+    "emoji": "🇬🇵",
+    "unicode": "U+1F1EC U+1F1F5",
+    "name": "Guadeloupe",
+    "title": "flag for Guadeloupe",
+
+  },
+  {
+    "code": "GQ",
+    "emoji": "🇬🇶",
+    "unicode": "U+1F1EC U+1F1F6",
+    "name": "Equatorial Guinea",
+    "title": "flag for Equatorial Guinea",
+
+  },
+  {
+    "code": "GR",
+    "emoji": "🇬🇷",
+    "unicode": "U+1F1EC U+1F1F7",
+    "name": "Greece",
+    "title": "flag for Greece",
+  },
+  {
+    "code": "GS",
+    "emoji": "🇬🇸",
+    "unicode": "U+1F1EC U+1F1F8",
+    "name": "South Georgia",
+    "title": "flag for South Georgia",
+
+  },
+  {
+    "code": "GT",
+    "emoji": "🇬🇹",
+    "unicode": "U+1F1EC U+1F1F9",
+    "name": "Guatemala",
+    "title": "flag for Guatemala",
+
+  },
+  {
+    "code": "GU",
+    "emoji": "🇬🇺",
+    "unicode": "U+1F1EC U+1F1FA",
+    "name": "Guam",
+    "title": "flag for Guam",
+  },
+  {
+    "code": "GW",
+    "emoji": "🇬🇼",
+    "unicode": "U+1F1EC U+1F1FC",
+    "name": "Guinea-Bissau",
+    "title": "flag for Guinea-Bissau",
+
+  },
+  {
+    "code": "GY",
+    "emoji": "🇬🇾",
+    "unicode": "U+1F1EC U+1F1FE",
+    "name": "Guyana",
+    "title": "flag for Guyana",
+
+  },
+  {
+    "code": "HK",
+    "emoji": "🇭🇰",
+    "unicode": "U+1F1ED U+1F1F0",
+    "name": "Hong Kong",
+    "title": "flag for Hong Kong",
+
+  },
+  {
+    "code": "HM",
+    "emoji": "🇭🇲",
+    "unicode": "U+1F1ED U+1F1F2",
+    "name": "Heard Island and Mcdonald Islands",
+    "title": "flag for Heard Island and Mcdonald Islands"
+  },
+  {
+    "code": "HN",
+    "emoji": "🇭🇳",
+    "unicode": "U+1F1ED U+1F1F3",
+    "name": "Honduras",
+    "title": "flag for Honduras",
+
+  },
+  {
+    "code": "HR",
+    "emoji": "🇭🇷",
+    "unicode": "U+1F1ED U+1F1F7",
+    "name": "Croatia",
+    "title": "flag for Croatia",
+
+  },
+  {
+    "code": "HT",
+    "emoji": "🇭🇹",
+    "unicode": "U+1F1ED U+1F1F9",
+    "name": "Haiti",
+    "title": "flag for Haiti",
+
+  },
+  {
+    "code": "HU",
+    "emoji": "🇭🇺",
+    "unicode": "U+1F1ED U+1F1FA",
+    "name": "Hungary",
+    "title": "flag for Hungary",
+  },
+  {
+    "code": "ID",
+    "emoji": "🇮🇩",
+    "unicode": "U+1F1EE U+1F1E9",
+    "name": "Indonesia",
+    "title": "flag for Indonesia",
+  },
+  {
+    "code": "IE",
+    "emoji": "🇮🇪",
+    "unicode": "U+1F1EE U+1F1EA",
+    "name": "Ireland",
+    "title": "flag for Ireland",
+
+  },
+  {
+    "code": "IL",
+    "emoji": "🇮🇱",
+    "unicode": "U+1F1EE U+1F1F1",
+    "name": "Israel",
+    "title": "flag for Israel",
+
+  },
+  {
+    "code": "IM",
+    "emoji": "🇮🇲",
+    "unicode": "U+1F1EE U+1F1F2",
+    "name": "Isle of Man",
+    "title": "flag for Isle of Man",
+  },
+  {
+    "code": "IN",
+    "emoji": "🇮🇳",
+    "unicode": "U+1F1EE U+1F1F3",
+    "name": "India",
+    "title": "flag for India",
+  },
+  {
+    "code": "IO",
+    "emoji": "🇮🇴",
+    "unicode": "U+1F1EE U+1F1F4",
+    "name": "British Indian Ocean Territory",
+    "title": "flag for British Indian Ocean Territory",
+
+  },
+  {
+    "code": "IQ",
+    "emoji": "🇮🇶",
+    "unicode": "U+1F1EE U+1F1F6",
+    "name": "Iraq",
+    "title": "flag for Iraq",
+
+  },
+  {
+    "code": "IR",
+    "emoji": "🇮🇷",
+    "unicode": "U+1F1EE U+1F1F7",
+    "name": "Iran",
+    "title": "flag for Iran",
+  },
+  {
+    "code": "IS",
+    "emoji": "🇮🇸",
+    "unicode": "U+1F1EE U+1F1F8",
+    "name": "Iceland",
+    "title": "flag for Iceland",
+
+  },
+  {
+    "code": "IT",
+    "emoji": "🇮🇹",
+    "unicode": "U+1F1EE U+1F1F9",
+    "name": "Italy",
+    "title": "flag for Italy",
+  },
+  {
+    "code": "JE",
+    "emoji": "🇯🇪",
+    "unicode": "U+1F1EF U+1F1EA",
+    "name": "Jersey",
+    "title": "flag for Jersey",
+  },
+  {
+    "code": "JM",
+    "emoji": "🇯🇲",
+    "unicode": "U+1F1EF U+1F1F2",
+    "name": "Jamaica",
+    "title": "flag for Jamaica",
+  },
+  {
+    "code": "JO",
+    "emoji": "🇯🇴",
+    "unicode": "U+1F1EF U+1F1F4",
+    "name": "Jordan",
+    "title": "flag for Jordan",
+
+  },
+  {
+    "code": "JP",
+    "emoji": "🇯🇵",
+    "unicode": "U+1F1EF U+1F1F5",
+    "name": "Japan",
+    "title": "flag for Japan",
+  },
+  {
+    "code": "KE",
+    "emoji": "🇰🇪",
+    "unicode": "U+1F1F0 U+1F1EA",
+    "name": "Kenya",
+    "title": "flag for Kenya",
+
+  },
+  {
+    "code": "KG",
+    "emoji": "🇰🇬",
+    "unicode": "U+1F1F0 U+1F1EC",
+    "name": "Kyrgyzstan",
+    "title": "flag for Kyrgyzstan",
+
+  },
+  {
+    "code": "KH",
+    "emoji": "🇰🇭",
+    "unicode": "U+1F1F0 U+1F1ED",
+    "name": "Cambodia",
+    "title": "flag for Cambodia",
+
+  },
+  {
+    "code": "KI",
+    "emoji": "🇰🇮",
+    "unicode": "U+1F1F0 U+1F1EE",
+    "name": "Kiribati",
+    "title": "flag for Kiribati",
+
+  },
+  {
+    "code": "KM",
+    "emoji": "🇰🇲",
+    "unicode": "U+1F1F0 U+1F1F2",
+    "name": "Comoros",
+    "title": "flag for Comoros",
+
+  },
+  {
+    "code": "KN",
+    "emoji": "🇰🇳",
+    "unicode": "U+1F1F0 U+1F1F3",
+    "name": "Saint Kitts and Nevis",
+    "title": "flag for Saint Kitts and Nevis",
+  },
+  {
+    "code": "KP",
+    "emoji": "🇰🇵",
+    "unicode": "U+1F1F0 U+1F1F5",
+    "name": "North Korea",
+    "title": "flag for North Korea",
+
+  },
+  {
+    "code": "KR",
+    "emoji": "🇰🇷",
+    "unicode": "U+1F1F0 U+1F1F7",
+    "name": "South Korea",
+    "title": "flag for South Korea",
+  },
+  {
+    "code": "KW",
+    "emoji": "🇰🇼",
+    "unicode": "U+1F1F0 U+1F1FC",
+    "name": "Kuwait",
+    "title": "flag for Kuwait",
+
+  },
+  {
+    "code": "KY",
+    "emoji": "🇰🇾",
+    "unicode": "U+1F1F0 U+1F1FE",
+    "name": "Cayman Islands",
+    "title": "flag for Cayman Islands",
+  },
+  {
+    "code": "KZ",
+    "emoji": "🇰🇿",
+    "unicode": "U+1F1F0 U+1F1FF",
+    "name": "Kazakhstan",
+    "title": "flag for Kazakhstan",
+
+  },
+  {
+    "code": "LA",
+    "emoji": "🇱🇦",
+    "unicode": "U+1F1F1 U+1F1E6",
+    "name": "Lao People's Democratic Republic",
+    "title": "flag for Lao People's Democratic Republic",
+
+  },
+  {
+    "code": "LB",
+    "emoji": "🇱🇧",
+    "unicode": "U+1F1F1 U+1F1E7",
+    "name": "Lebanon",
+    "title": "flag for Lebanon",
+
+  },
+  {
+    "code": "LC",
+    "emoji": "🇱🇨",
+    "unicode": "U+1F1F1 U+1F1E8",
+    "name": "Saint Lucia",
+    "title": "flag for Saint Lucia",
+  },
+  {
+    "code": "LI",
+    "emoji": "🇱🇮",
+    "unicode": "U+1F1F1 U+1F1EE",
+    "name": "Liechtenstein",
+    "title": "flag for Liechtenstein",
+
+  },
+  {
+    "code": "LK",
+    "emoji": "🇱🇰",
+    "unicode": "U+1F1F1 U+1F1F0",
+    "name": "Sri Lanka",
+    "title": "flag for Sri Lanka",
+  },
+  {
+    "code": "LR",
+    "emoji": "🇱🇷",
+    "unicode": "U+1F1F1 U+1F1F7",
+    "name": "Liberia",
+    "title": "flag for Liberia",
+
+  },
+  {
+    "code": "LS",
+    "emoji": "🇱🇸",
+    "unicode": "U+1F1F1 U+1F1F8",
+    "name": "Lesotho",
+    "title": "flag for Lesotho",
+
+  },
+  {
+    "code": "LT",
+    "emoji": "🇱🇹",
+    "unicode": "U+1F1F1 U+1F1F9",
+    "name": "Lithuania",
+    "title": "flag for Lithuania",
+
+  },
+  {
+    "code": "LU",
+    "emoji": "🇱🇺",
+    "unicode": "U+1F1F1 U+1F1FA",
+    "name": "Luxembourg",
+    "title": "flag for Luxembourg",
+
+  },
+  {
+    "code": "LV",
+    "emoji": "🇱🇻",
+    "unicode": "U+1F1F1 U+1F1FB",
+    "name": "Latvia",
+    "title": "flag for Latvia",
+
+  },
+  {
+    "code": "LY",
+    "emoji": "🇱🇾",
+    "unicode": "U+1F1F1 U+1F1FE",
+    "name": "Libya",
+    "title": "flag for Libya",
+
+  },
+  {
+    "code": "MA",
+    "emoji": "🇲🇦",
+    "unicode": "U+1F1F2 U+1F1E6",
+    "name": "Morocco",
+    "title": "flag for Morocco",
+
+  },
+  {
+    "code": "MC",
+    "emoji": "🇲🇨",
+    "unicode": "U+1F1F2 U+1F1E8",
+    "name": "Monaco",
+    "title": "flag for Monaco",
+
+  },
+  {
+    "code": "MD",
+    "emoji": "🇲🇩",
+    "unicode": "U+1F1F2 U+1F1E9",
+    "name": "Moldova",
+    "title": "flag for Moldova",
+
+  },
+  {
+    "code": "ME",
+    "emoji": "🇲🇪",
+    "unicode": "U+1F1F2 U+1F1EA",
+    "name": "Montenegro",
+    "title": "flag for Montenegro",
+
+  },
+  {
+    "code": "MF",
+    "emoji": "🇲🇫",
+    "unicode": "U+1F1F2 U+1F1EB",
+    "name": "Saint Martin (French Part)",
+    "title": "flag for Saint Martin (French Part)",
+
+  },
+  {
+    "code": "MG",
+    "emoji": "🇲🇬",
+    "unicode": "U+1F1F2 U+1F1EC",
+    "name": "Madagascar",
+    "title": "flag for Madagascar",
+
+  },
+  {
+    "code": "MH",
+    "emoji": "🇲🇭",
+    "unicode": "U+1F1F2 U+1F1ED",
+    "name": "Marshall Islands",
+    "title": "flag for Marshall Islands",
+
+  },
+  {
+    "code": "MK",
+    "emoji": "🇲🇰",
+    "unicode": "U+1F1F2 U+1F1F0",
+    "name": "Macedonia",
+    "title": "flag for Macedonia",
+
+  },
+  {
+    "code": "ML",
+    "emoji": "🇲🇱",
+    "unicode": "U+1F1F2 U+1F1F1",
+    "name": "Mali",
+    "title": "flag for Mali",
+
+  },
+  {
+    "code": "MM",
+    "emoji": "🇲🇲",
+    "unicode": "U+1F1F2 U+1F1F2",
+    "name": "Myanmar",
+    "title": "flag for Myanmar",
+  },
+  {
+    "code": "MN",
+    "emoji": "🇲🇳",
+    "unicode": "U+1F1F2 U+1F1F3",
+    "name": "Mongolia",
+    "title": "flag for Mongolia",
+
+  },
+  {
+    "code": "MO",
+    "emoji": "🇲🇴",
+    "unicode": "U+1F1F2 U+1F1F4",
+    "name": "Macao",
+    "title": "flag for Macao",
+
+  },
+  {
+    "code": "MP",
+    "emoji": "🇲🇵",
+    "unicode": "U+1F1F2 U+1F1F5",
+    "name": "Northern Mariana Islands",
+    "title": "flag for Northern Mariana Islands",
+  },
+  {
+    "code": "MQ",
+    "emoji": "🇲🇶",
+    "unicode": "U+1F1F2 U+1F1F6",
+    "name": "Martinique",
+    "title": "flag for Martinique",
+
+  },
+  {
+    "code": "MR",
+    "emoji": "🇲🇷",
+    "unicode": "U+1F1F2 U+1F1F7",
+    "name": "Mauritania",
+    "title": "flag for Mauritania",
+
+  },
+  {
+    "code": "MS",
+    "emoji": "🇲🇸",
+    "unicode": "U+1F1F2 U+1F1F8",
+    "name": "Montserrat",
+    "title": "flag for Montserrat",
+  },
+  {
+    "code": "MT",
+    "emoji": "🇲🇹",
+    "unicode": "U+1F1F2 U+1F1F9",
+    "name": "Malta",
+    "title": "flag for Malta",
+
+  },
+  {
+    "code": "MU",
+    "emoji": "🇲🇺",
+    "unicode": "U+1F1F2 U+1F1FA",
+    "name": "Mauritius",
+    "title": "flag for Mauritius",
+
+  },
+  {
+    "code": "MV",
+    "emoji": "🇲🇻",
+    "unicode": "U+1F1F2 U+1F1FB",
+    "name": "Maldives",
+    "title": "flag for Maldives",
+
+  },
+  {
+    "code": "MW",
+    "emoji": "🇲🇼",
+    "unicode": "U+1F1F2 U+1F1FC",
+    "name": "Malawi",
+    "title": "flag for Malawi",
+
+  },
+  {
+    "code": "MX",
+    "emoji": "🇲🇽",
+    "unicode": "U+1F1F2 U+1F1FD",
+    "name": "Mexico",
+    "title": "flag for Mexico",
+  },
+  {
+    "code": "MY",
+    "emoji": "🇲🇾",
+    "unicode": "U+1F1F2 U+1F1FE",
+    "name": "Malaysia",
+    "title": "flag for Malaysia",
+  },
+  {
+    "code": "MZ",
+    "emoji": "🇲🇿",
+    "unicode": "U+1F1F2 U+1F1FF",
+    "name": "Mozambique",
+    "title": "flag for Mozambique",
+
+  },
+  {
+    "code": "NA",
+    "emoji": "🇳🇦",
+    "unicode": "U+1F1F3 U+1F1E6",
+    "name": "Namibia",
+    "title": "flag for Namibia",
+
+  },
+  {
+    "code": "NC",
+    "emoji": "🇳🇨",
+    "unicode": "U+1F1F3 U+1F1E8",
+    "name": "New Caledonia",
+    "title": "flag for New Caledonia",
+
+  },
+  {
+    "code": "NE",
+    "emoji": "🇳🇪",
+    "unicode": "U+1F1F3 U+1F1EA",
+    "name": "Niger",
+    "title": "flag for Niger",
+
+  },
+  {
+    "code": "NF",
+    "emoji": "🇳🇫",
+    "unicode": "U+1F1F3 U+1F1EB",
+    "name": "Norfolk Island",
+    "title": "flag for Norfolk Island",
+
+  },
+  {
+    "code": "NG",
+    "emoji": "🇳🇬",
+    "unicode": "U+1F1F3 U+1F1EC",
+    "name": "Nigeria",
+    "title": "flag for Nigeria",
+
+  },
+  {
+    "code": "NI",
+    "emoji": "🇳🇮",
+    "unicode": "U+1F1F3 U+1F1EE",
+    "name": "Nicaragua",
+    "title": "flag for Nicaragua",
+
+  },
+  {
+    "code": "NL",
+    "emoji": "🇳🇱",
+    "unicode": "U+1F1F3 U+1F1F1",
+    "name": "Netherlands",
+    "title": "flag for Netherlands",
+  },
+  {
+    "code": "NO",
+    "emoji": "🇳🇴",
+    "unicode": "U+1F1F3 U+1F1F4",
+    "name": "Norway",
+    "title": "flag for Norway",
+  },
+  {
+    "code": "NP",
+    "emoji": "🇳🇵",
+    "unicode": "U+1F1F3 U+1F1F5",
+    "name": "Nepal",
+    "title": "flag for Nepal",
+
+  },
+  {
+    "code": "NR",
+    "emoji": "🇳🇷",
+    "unicode": "U+1F1F3 U+1F1F7",
+    "name": "Nauru",
+    "title": "flag for Nauru",
+
+  },
+  {
+    "code": "NU",
+    "emoji": "🇳🇺",
+    "unicode": "U+1F1F3 U+1F1FA",
+    "name": "Niue",
+    "title": "flag for Niue",
+
+  },
+  {
+    "code": "NZ",
+    "emoji": "🇳🇿",
+    "unicode": "U+1F1F3 U+1F1FF",
+    "name": "New Zealand",
+    "title": "flag for New Zealand",
+  },
+  {
+    "code": "OM",
+    "emoji": "🇴🇲",
+    "unicode": "U+1F1F4 U+1F1F2",
+    "name": "Oman",
+    "title": "flag for Oman",
+
+  },
+  {
+    "code": "PA",
+    "emoji": "🇵🇦",
+    "unicode": "U+1F1F5 U+1F1E6",
+    "name": "Panama",
+    "title": "flag for Panama",
+
+  },
+  {
+    "code": "PE",
+    "emoji": "🇵🇪",
+    "unicode": "U+1F1F5 U+1F1EA",
+    "name": "Peru",
+    "title": "flag for Peru",
+  },
+  {
+    "code": "PF",
+    "emoji": "🇵🇫",
+    "unicode": "U+1F1F5 U+1F1EB",
+    "name": "French Polynesia",
+    "title": "flag for French Polynesia",
+
+  },
+  {
+    "code": "PG",
+    "emoji": "🇵🇬",
+    "unicode": "U+1F1F5 U+1F1EC",
+    "name": "Papua New Guinea",
+    "title": "flag for Papua New Guinea",
+
+  },
+  {
+    "code": "PH",
+    "emoji": "🇵🇭",
+    "unicode": "U+1F1F5 U+1F1ED",
+    "name": "Philippines",
+    "title": "flag for Philippines",
+  },
+  {
+    "code": "PK",
+    "emoji": "🇵🇰",
+    "unicode": "U+1F1F5 U+1F1F0",
+    "name": "Pakistan",
+    "title": "flag for Pakistan",
+  },
+  {
+    "code": "PL",
+    "emoji": "🇵🇱",
+    "unicode": "U+1F1F5 U+1F1F1",
+    "name": "Poland",
+    "title": "flag for Poland",
+  },
+  {
+    "code": "PM",
+    "emoji": "🇵🇲",
+    "unicode": "U+1F1F5 U+1F1F2",
+    "name": "Saint Pierre and Miquelon",
+    "title": "flag for Saint Pierre and Miquelon",
+
+  },
+  {
+    "code": "PN",
+    "emoji": "🇵🇳",
+    "unicode": "U+1F1F5 U+1F1F3",
+    "name": "Pitcairn",
+    "title": "flag for Pitcairn",
+
+  },
+  {
+    "code": "PR",
+    "emoji": "🇵🇷",
+    "unicode": "U+1F1F5 U+1F1F7",
+    "name": "Puerto Rico",
+    "title": "flag for Puerto Rico",
+  },
+  {
+    "code": "PS",
+    "emoji": "🇵🇸",
+    "unicode": "U+1F1F5 U+1F1F8",
+    "name": "Palestinian Territory",
+    "title": "flag for Palestinian Territory",
+
+  },
+  {
+    "code": "PT",
+    "emoji": "🇵🇹",
+    "unicode": "U+1F1F5 U+1F1F9",
+    "name": "Portugal",
+    "title": "flag for Portugal",
+
+  },
+  {
+    "code": "PW",
+    "emoji": "🇵🇼",
+    "unicode": "U+1F1F5 U+1F1FC",
+    "name": "Palau",
+    "title": "flag for Palau",
+
+  },
+  {
+    "code": "PY",
+    "emoji": "🇵🇾",
+    "unicode": "U+1F1F5 U+1F1FE",
+    "name": "Paraguay",
+    "title": "flag for Paraguay",
+
+  },
+  {
+    "code": "QA",
+    "emoji": "🇶🇦",
+    "unicode": "U+1F1F6 U+1F1E6",
+    "name": "Qatar",
+    "title": "flag for Qatar",
+
+  },
+  {
+    "code": "RE",
+    "emoji": "🇷🇪",
+    "unicode": "U+1F1F7 U+1F1EA",
+    "name": "Réunion",
+    "title": "flag for Réunion",
+
+  },
+  {
+    "code": "RO",
+    "emoji": "🇷🇴",
+    "unicode": "U+1F1F7 U+1F1F4",
+    "name": "Romania",
+    "title": "flag for Romania",
+  },
+  {
+    "code": "RS",
+    "emoji": "🇷🇸",
+    "unicode": "U+1F1F7 U+1F1F8",
+    "name": "Serbia",
+    "title": "flag for Serbia",
+
+  },
+  {
+    "code": "RU",
+    "emoji": "🇷🇺",
+    "unicode": "U+1F1F7 U+1F1FA",
+    "name": "Russia",
+    "title": "flag for Russia",
+  },
+  {
+    "code": "RW",
+    "emoji": "🇷🇼",
+    "unicode": "U+1F1F7 U+1F1FC",
+    "name": "Rwanda",
+    "title": "flag for Rwanda",
+
+  },
+  {
+    "code": "SA",
+    "emoji": "🇸🇦",
+    "unicode": "U+1F1F8 U+1F1E6",
+    "name": "Saudi Arabia",
+    "title": "flag for Saudi Arabia",
+
+  },
+  {
+    "code": "SB",
+    "emoji": "🇸🇧",
+    "unicode": "U+1F1F8 U+1F1E7",
+    "name": "Solomon Islands",
+    "title": "flag for Solomon Islands",
+
+  },
+  {
+    "code": "SC",
+    "emoji": "🇸🇨",
+    "unicode": "U+1F1F8 U+1F1E8",
+    "name": "Seychelles",
+    "title": "flag for Seychelles",
+
+  },
+  {
+    "code": "SD",
+    "emoji": "🇸🇩",
+    "unicode": "U+1F1F8 U+1F1E9",
+    "name": "Sudan",
+    "title": "flag for Sudan",
+
+  },
+  {
+    "code": "SE",
+    "emoji": "🇸🇪",
+    "unicode": "U+1F1F8 U+1F1EA",
+    "name": "Sweden",
+    "title": "flag for Sweden",
+  },
+  {
+    "code": "SG",
+    "emoji": "🇸🇬",
+    "unicode": "U+1F1F8 U+1F1EC",
+    "name": "Singapore",
+    "title": "flag for Singapore",
+  },
+  {
+    "code": "SH",
+    "emoji": "🇸🇭",
+    "unicode": "U+1F1F8 U+1F1ED",
+    "name": "Saint Helena, Ascension and Tristan Da Cunha",
+    "title": "flag for Saint Helena, Ascension and Tristan Da Cunha",
+
+  },
+  {
+    "code": "SI",
+    "emoji": "🇸🇮",
+    "unicode": "U+1F1F8 U+1F1EE",
+    "name": "Slovenia",
+    "title": "flag for Slovenia",
+
+  },
+  {
+    "code": "SJ",
+    "emoji": "🇸🇯",
+    "unicode": "U+1F1F8 U+1F1EF",
+    "name": "Svalbard and Jan Mayen",
+    "title": "flag for Svalbard and Jan Mayen",
+  },
+  {
+    "code": "SK",
+    "emoji": "🇸🇰",
+    "unicode": "U+1F1F8 U+1F1F0",
+    "name": "Slovakia",
+    "title": "flag for Slovakia",
+
+  },
+  {
+    "code": "SL",
+    "emoji": "🇸🇱",
+    "unicode": "U+1F1F8 U+1F1F1",
+    "name": "Sierra Leone",
+    "title": "flag for Sierra Leone",
+
+  },
+  {
+    "code": "SM",
+    "emoji": "🇸🇲",
+    "unicode": "U+1F1F8 U+1F1F2",
+    "name": "San Marino",
+    "title": "flag for San Marino",
+
+  },
+  {
+    "code": "SN",
+    "emoji": "🇸🇳",
+    "unicode": "U+1F1F8 U+1F1F3",
+    "name": "Senegal",
+    "title": "flag for Senegal",
+
+  },
+  {
+    "code": "SO",
+    "emoji": "🇸🇴",
+    "unicode": "U+1F1F8 U+1F1F4",
+    "name": "Somalia",
+    "title": "flag for Somalia",
+
+  },
+  {
+    "code": "SR",
+    "emoji": "🇸🇷",
+    "unicode": "U+1F1F8 U+1F1F7",
+    "name": "Suriname",
+    "title": "flag for Suriname",
+
+  },
+  {
+    "code": "SS",
+    "emoji": "🇸🇸",
+    "unicode": "U+1F1F8 U+1F1F8",
+    "name": "South Sudan",
+    "title": "flag for South Sudan"
+  },
+  {
+    "code": "ST",
+    "emoji": "🇸🇹",
+    "unicode": "U+1F1F8 U+1F1F9",
+    "name": "Sao Tome and Principe",
+    "title": "flag for Sao Tome and Principe",
+
+  },
+  {
+    "code": "SV",
+    "emoji": "🇸🇻",
+    "unicode": "U+1F1F8 U+1F1FB",
+    "name": "El Salvador",
+    "title": "flag for El Salvador",
+
+  },
+  {
+    "code": "SX",
+    "emoji": "🇸🇽",
+    "unicode": "U+1F1F8 U+1F1FD",
+    "name": "Sint Maarten (Dutch Part)",
+    "title": "flag for Sint Maarten (Dutch Part)"
+  },
+  {
+    "code": "SY",
+    "emoji": "🇸🇾",
+    "unicode": "U+1F1F8 U+1F1FE",
+    "name": "Syrian Arab Republic",
+    "title": "flag for Syrian Arab Republic",
+
+  },
+  {
+    "code": "SZ",
+    "emoji": "🇸🇿",
+    "unicode": "U+1F1F8 U+1F1FF",
+    "name": "Swaziland",
+    "title": "flag for Swaziland",
+
+  },
+  {
+    "code": "TC",
+    "emoji": "🇹🇨",
+    "unicode": "U+1F1F9 U+1F1E8",
+    "name": "Turks and Caicos Islands",
+    "title": "flag for Turks and Caicos Islands",
+  },
+  {
+    "code": "TD",
+    "emoji": "🇹🇩",
+    "unicode": "U+1F1F9 U+1F1E9",
+    "name": "Chad",
+    "title": "flag for Chad",
+
+  },
+  {
+    "code": "TF",
+    "emoji": "🇹🇫",
+    "unicode": "U+1F1F9 U+1F1EB",
+    "name": "French Southern Territories",
+    "title": "flag for French Southern Territories"
+  },
+  {
+    "code": "TG",
+    "emoji": "🇹🇬",
+    "unicode": "U+1F1F9 U+1F1EC",
+    "name": "Togo",
+    "title": "flag for Togo",
+
+  },
+  {
+    "code": "TH",
+    "emoji": "🇹🇭",
+    "unicode": "U+1F1F9 U+1F1ED",
+    "name": "Thailand",
+    "title": "flag for Thailand",
+  },
+  {
+    "code": "TJ",
+    "emoji": "🇹🇯",
+    "unicode": "U+1F1F9 U+1F1EF",
+    "name": "Tajikistan",
+    "title": "flag for Tajikistan",
+
+  },
+  {
+    "code": "TK",
+    "emoji": "🇹🇰",
+    "unicode": "U+1F1F9 U+1F1F0",
+    "name": "Tokelau",
+    "title": "flag for Tokelau",
+
+  },
+  {
+    "code": "TL",
+    "emoji": "🇹🇱",
+    "unicode": "U+1F1F9 U+1F1F1",
+    "name": "Timor-Leste",
+    "title": "flag for Timor-Leste",
+
+  },
+  {
+    "code": "TM",
+    "emoji": "🇹🇲",
+    "unicode": "U+1F1F9 U+1F1F2",
+    "name": "Turkmenistan",
+    "title": "flag for Turkmenistan",
+
+  },
+  {
+    "code": "TN",
+    "emoji": "🇹🇳",
+    "unicode": "U+1F1F9 U+1F1F3",
+    "name": "Tunisia",
+    "title": "flag for Tunisia",
+
+  },
+  {
+    "code": "TO",
+    "emoji": "🇹🇴",
+    "unicode": "U+1F1F9 U+1F1F4",
+    "name": "Tonga",
+    "title": "flag for Tonga",
+
+  },
+  {
+    "code": "TR",
+    "emoji": "🇹🇷",
+    "unicode": "U+1F1F9 U+1F1F7",
+    "name": "Turkey",
+    "title": "flag for Turkey",
+  },
+  {
+    "code": "TT",
+    "emoji": "🇹🇹",
+    "unicode": "U+1F1F9 U+1F1F9",
+    "name": "Trinidad and Tobago",
+    "title": "flag for Trinidad and Tobago",
+  },
+  {
+    "code": "TV",
+    "emoji": "🇹🇻",
+    "unicode": "U+1F1F9 U+1F1FB",
+    "name": "Tuvalu",
+    "title": "flag for Tuvalu",
+
+  },
+  {
+    "code": "TW",
+    "emoji": "🇹🇼",
+    "unicode": "U+1F1F9 U+1F1FC",
+    "name": "Taiwan",
+    "title": "flag for Taiwan",
+
+  },
+  {
+    "code": "TZ",
+    "emoji": "🇹🇿",
+    "unicode": "U+1F1F9 U+1F1FF",
+    "name": "Tanzania",
+    "title": "flag for Tanzania",
+
+  },
+  {
+    "code": "UA",
+    "emoji": "🇺🇦",
+    "unicode": "U+1F1FA U+1F1E6",
+    "name": "Ukraine",
+    "title": "flag for Ukraine",
+
+  },
+  {
+    "code": "UG",
+    "emoji": "🇺🇬",
+    "unicode": "U+1F1FA U+1F1EC",
+    "name": "Uganda",
+    "title": "flag for Uganda",
+
+  },
+  {
+    "code": "UM",
+    "emoji": "🇺🇲",
+    "unicode": "U+1F1FA U+1F1F2",
+    "name": "United States Minor Outlying Islands",
+    "title": "flag for United States Minor Outlying Islands"
+  },
+  {
+    "code": "US",
+    "emoji": "🇺🇸",
+    "unicode": "U+1F1FA U+1F1F8",
+    "name": "United States",
+    "title": "flag for United States",
+  },
+  {
+    "code": "UY",
+    "emoji": "🇺🇾",
+    "unicode": "U+1F1FA U+1F1FE",
+    "name": "Uruguay",
+    "title": "flag for Uruguay",
+
+  },
+  {
+    "code": "UZ",
+    "emoji": "🇺🇿",
+    "unicode": "U+1F1FA U+1F1FF",
+    "name": "Uzbekistan",
+    "title": "flag for Uzbekistan",
+
+  },
+  {
+    "code": "VA",
+    "emoji": "🇻🇦",
+    "unicode": "U+1F1FB U+1F1E6",
+    "name": "Vatican City",
+    "title": "flag for Vatican City",
+
+  },
+  {
+    "code": "VC",
+    "emoji": "🇻🇨",
+    "unicode": "U+1F1FB U+1F1E8",
+    "name": "Saint Vincent and The Grenadines",
+    "title": "flag for Saint Vincent and The Grenadines",
+  },
+  {
+    "code": "VE",
+    "emoji": "🇻🇪",
+    "unicode": "U+1F1FB U+1F1EA",
+    "name": "Venezuela",
+    "title": "flag for Venezuela",
+  },
+  {
+    "code": "VG",
+    "emoji": "🇻🇬",
+    "unicode": "U+1F1FB U+1F1EC",
+    "name": "Virgin Islands, British",
+    "title": "flag for Virgin Islands, British",
+  },
+  {
+    "code": "VI",
+    "emoji": "🇻🇮",
+    "unicode": "U+1F1FB U+1F1EE",
+    "name": "Virgin Islands, U.S.",
+    "title": "flag for Virgin Islands, U.S.",
+  },
+  {
+    "code": "VN",
+    "emoji": "🇻🇳",
+    "unicode": "U+1F1FB U+1F1F3",
+    "name": "Viet Nam",
+    "title": "flag for Viet Nam",
+  },
+  {
+    "code": "VU",
+    "emoji": "🇻🇺",
+    "unicode": "U+1F1FB U+1F1FA",
+    "name": "Vanuatu",
+    "title": "flag for Vanuatu",
+
+  },
+  {
+    "code": "WF",
+    "emoji": "🇼🇫",
+    "unicode": "U+1F1FC U+1F1EB",
+    "name": "Wallis and Futuna",
+    "title": "flag for Wallis and Futuna",
+
+  },
+  {
+    "code": "WS",
+    "emoji": "🇼🇸",
+    "unicode": "U+1F1FC U+1F1F8",
+    "name": "Samoa",
+    "title": "flag for Samoa",
+
+  },
+  {
+    "code": "XK",
+    "emoji": "🇽🇰",
+    "unicode": "U+1F1FD U+1F1F0",
+    "name": "Kosovo",
+    "title": "flag for Kosovo",
+
+  },
+  {
+    "code": "YE",
+    "emoji": "🇾🇪",
+    "unicode": "U+1F1FE U+1F1EA",
+    "name": "Yemen",
+    "title": "flag for Yemen",
+
+  },
+  {
+    "code": "YT",
+    "emoji": "🇾🇹",
+    "unicode": "U+1F1FE U+1F1F9",
+    "name": "Mayotte",
+    "title": "flag for Mayotte",
+
+  },
+  {
+    "code": "ZA",
+    "emoji": "🇿🇦",
+    "unicode": "U+1F1FF U+1F1E6",
+    "name": "South Africa",
+    "title": "flag for South Africa",
+  },
+  {
+    "code": "ZM",
+    "emoji": "🇿🇲",
+    "unicode": "U+1F1FF U+1F1F2",
+    "name": "Zambia",
+    "title": "flag for Zambia"
+  },
+  {
+    "code": "ZW",
+    "emoji": "🇿🇼",
+    "unicode": "U+1F1FF U+1F1FC",
+    "name": "Zimbabwe",
+    "title": "flag for Zimbabwe"
+  }
+]

--- a/src/collections/flagEmojis.ts
+++ b/src/collections/flagEmojis.ts
@@ -598,6 +598,13 @@ export const countries: Country[] = [
     "title": "flag for United Kingdom",
   },
   {
+    "code": "GB",
+    "emoji": "🇬🇧",
+    "unicode": "U+1F1EC U+1F1E7",
+    "name": "UK",
+    "title": "flag for United Kingdom",
+  },
+  {
     "code": "GD",
     "emoji": "🇬🇩",
     "unicode": "U+1F1EC U+1F1E9",
@@ -1789,14 +1796,14 @@ export const countries: Country[] = [
     "code": "UM",
     "emoji": "🇺🇲",
     "unicode": "U+1F1FA U+1F1F2",
-    "name": "United States Minor Outlying Islands",
+    "name": "USA",
     "title": "flag for United States Minor Outlying Islands"
   },
   {
     "code": "US",
     "emoji": "🇺🇸",
     "unicode": "U+1F1FA U+1F1F8",
-    "name": "United States",
+    "name": "USA",
     "title": "flag for United States",
   },
   {

--- a/src/common/moderator.ts
+++ b/src/common/moderator.ts
@@ -14,3 +14,7 @@ export const isAuthorModerator = (message: Message):boolean => {
 export const hasRole = (member: GuildMember | PartialGuildMember, roleName: string): boolean => {
    return !!member.roles.cache.find(r => r.name === roleName)
 }
+
+export const isRegistered = (member:GuildMember | PartialGuildMember):boolean => {
+   return !!member.roles.cache.find(role => role.name.startsWith("I'm from "))
+}

--- a/src/common/moderator.ts
+++ b/src/common/moderator.ts
@@ -1,5 +1,6 @@
-import { Message, GuildMember, PartialGuildMember } from "discord.js"
-import { MODERATOR_ROLE_NAME } from "../const"
+import { Message, GuildMember, PartialGuildMember, TextChannel } from "discord.js"
+import { MODERATOR_ROLE_NAME, OUTPUT_CHANNEL_ID, GUILD_ID } from "../const"
+import bot from "..";
 
 export const isAuthorModerator = (message: Message):boolean => {
    if(message.member.roles.hoist) {
@@ -17,4 +18,14 @@ export const hasRole = (member: GuildMember | PartialGuildMember, roleName: stri
 
 export const isRegistered = (member:GuildMember | PartialGuildMember):boolean => {
    return !!member.roles.cache.find(role => role.name.startsWith("I'm from "))
+}
+
+export const textLog = (text:string): Promise<Message> => {
+   
+   const outputChannel = <TextChannel>bot.channels.resolve(OUTPUT_CHANNEL_ID)
+   return outputChannel.send(text)
+}
+
+export const getMember = (userId:string): GuildMember => {
+   return bot.guilds.resolve(GUILD_ID).members.resolve(userId)
 }

--- a/src/events/MemberJoin.ts
+++ b/src/events/MemberJoin.ts
@@ -15,7 +15,7 @@ class MemberJoin {
         `Hey ${member.toString()}. What's your name? :grin: You've just joined the Yes Theory Fam Discord Server! Drop where you're from in here so you can be given access to all the channels. Don't forget to also read the <#450102410262609943>. In the meantime you can go say hi to a couple of our friends in <#689589205755625641>! :heart: `
     ]
         let message = messages[Math.floor(Math.random()*messages.length)]
-        //welcomeChannel.send(message)
+        welcomeChannel.send(message)
 
 
     }

--- a/src/events/MemberJoin.ts
+++ b/src/events/MemberJoin.ts
@@ -15,7 +15,7 @@ class MemberJoin {
         `Hey ${member.toString()}. What's your name? :grin: You've just joined the Yes Theory Fam Discord Server! Drop where you're from in here so you can be given access to all the channels. Don't forget to also read the <#450102410262609943>. In the meantime you can go say hi to a couple of our friends in <#689589205755625641>! :heart: `
     ]
         let message = messages[Math.floor(Math.random()*messages.length)]
-        welcomeChannel.send(message)
+        //welcomeChannel.send(message)
 
 
     }

--- a/src/events/MessageManager.ts
+++ b/src/events/MessageManager.ts
@@ -98,7 +98,7 @@ class MessageManager {
         }
 
         async routeDm() {
-            this.message.reply("Nice DM")
+            this.message.reply("I've sent your name request to the mods, hopefully they answer soon! In the meantime, you're free to roam around the server and explore. Maybe post an introduction to get started? :grin:")
             const message = `Username: ${this.message.author.toString()} would like to rename to "${this.message.content}". Allow?`;
             const sentMessage = await textLog(message)
             sentMessage.react("✅").then(message => sentMessage.react("🚫"))

--- a/src/events/MessageManager.ts
+++ b/src/events/MessageManager.ts
@@ -10,6 +10,7 @@ class MessageManager {
     message: Discord.Message;
     author: Discord.User;
     bot: Discord.Client;
+    logs: boolean;
 
     constructor(msg: Discord.Message) {
         this.message = msg;
@@ -18,7 +19,7 @@ class MessageManager {
         this.routeMessage();
     }
     routeMessage() {
-        
+
         const words = this.message.content.split(" ")
         const firstWord = words[0];
         const channel = <Discord.TextChannel>this.message.channel;
@@ -27,11 +28,12 @@ class MessageManager {
 
             case "where-are-you-from":
             case "welcome-chat":
+            case "flag-drop":
                 if (firstWord == "!usa") this.SendMap('usa');
                 if (firstWord == "!canada") this.SendMap('canada');
                 if (firstWord == "!australia") this.SendMap('australia');
-                if (firstWord == "!uk") this.SendMap('uk');;
-                WhereAreYouFromManager(this.message)
+                if (firstWord == "!uk") this.SendMap('uk');
+                WhereAreYouFromManager(this.message);
                 if(firstWord === "!state") StateRoleFinder(this.message);
                 break;
 
@@ -86,7 +88,7 @@ class MessageManager {
             if (firstWord === "F") this.message.react("🇫");
             if (["i love u yesbot", "i love you yesbot", "yesbot i love you "].includes(this.message.content.toLowerCase())) this.sendLove();
             if (this.message.content.toLowerCase().startsWith("yesbot") && this.message.content.toLowerCase().endsWith('?')) this.randomReply();
-            
+             
 
         }
 
@@ -134,9 +136,7 @@ randomReply() {
     let replies = ["yes.", "probably.", "doubtful.", "i'm afraid I don't know that one", "absolutely not.", "not a chance.", "definitely.", "very very very unlikely"];
     this.message.reply(replies[Math.floor(Math.random()*replies.length)])
 }
-sendLove() {
-    console.log(this.message.member);
-    
+sendLove() {    
     this.message.reply("I love you too! (Although I'm not entirely sure what love is but this experience I'm feeling is probably some iteration of love.)")
     this.message.react("😍");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import {Client, Channel, Emoji, Guild, GuildMember, PartialGuildMember, Message, User, PartialUser, Collection, Role, TextChannel, Snowflake, MessageReaction, Speaking, PartialMessage, Presence, VoiceState,} from 'discord.js';
 import { MessageManager, ReactionAdd, ReactionRemove, Ready, MemberJoin, GuildMemberUpdate } from './events';
-import { BOT_TOKEN, GUILD_ID, OUTPUT_CHANNEL_ID } from './const';
+import { BOT_TOKEN, GUILD_ID } from './const';
 import Firebase from './collections/firebaseConnection';
 
 
@@ -51,10 +51,5 @@ bot.on("voiceStateUpdate", (oldMember: VoiceState, newMember: VoiceState) => nul
 bot.on("warn",  (info: string) => null);
 bot.on("webhookUpdate", (channel: TextChannel) => null);
 //! ================= /EVENT HANDLERS ===================
-process.on("beforeExit", () => {
-   const guild = bot.guilds.resolve(GUILD_ID)
-   const outputChannel = <TextChannel>guild.channels.resolve(OUTPUT_CHANNEL_ID)
-   outputChannel.send(`Looks like I'm about to die. Please check in this channel to ensure I restart ok.`)
-})
 
 export default bot;

--- a/src/programs/EasterEvent.ts
+++ b/src/programs/EasterEvent.ts
@@ -56,7 +56,6 @@ export default async function EasterEvent(msg: Discord.Message) {
 
 (function loop() {
     var rand = Math.round(Math.random() * EGG_DELAY_SECONDS * 1000);
-    console.log(rand)
     setTimeout(() =>{
             if(EASTER_EVENT) sendEgg();
             loop();  

--- a/src/programs/GroupManager.ts
+++ b/src/programs/GroupManager.ts
@@ -1,7 +1,6 @@
 import Discord, { Snowflake, TextChannel, GuildMember, Message, MessageEmbed, MessageReaction, User } from 'discord.js';
 import Tools from '../common/tools';
 import { MODERATOR_ROLE_NAME, ENGINEER_ROLE_NAME } from '../const';
-import { group } from 'console';
 import { isAuthorModerator } from '../common/moderator';
 
 interface DiscordGroup {

--- a/src/programs/ReactRole.ts
+++ b/src/programs/ReactRole.ts
@@ -1,4 +1,4 @@
-import Discord, {Snowflake, TextChannel} from 'discord.js';
+import Discord, {Snowflake, TextChannel, Message} from 'discord.js';
 import Tools from '../common/tools';
 import { MODERATOR_ROLE_NAME } from '../const';
 import { isAuthorModerator } from '../common/moderator';
@@ -15,7 +15,7 @@ export default async function ReactRole(message: Discord.Message) {
     const [action, messageId, reaction, roleId, channelId] = words
     const workingChannel:Discord.Channel = channelId ? message.guild.channels.resolve(channelId) : message.channel;
 
-    if(!action || !(["add","list","delete"].includes(action))){
+    if(!action || !(["add","list","delete", "search"].includes(action))){
         message.reply(`Incorrect syntax, please use the following: \`!roles add|list|delete\``);
         return;
     }
@@ -31,8 +31,20 @@ export default async function ReactRole(message: Discord.Message) {
             listReactRoleObjects(message)
         case "delete":
             deleteReactRoleObjects(words[1], message)
+        case "search":
+            searchForRole(words[1], message)
         default:
             break;
+    }
+}
+
+const searchForRole = async (roleSearchString:string, message:Message) => {
+    const foundRole = message.guild.roles.cache.find(role => role.name.toLowerCase().includes(roleSearchString.toLowerCase()));
+    if(!foundRole) {
+        message.reply("I couldn't find that role!")
+    }
+    else {
+        message.reply(`There are ${foundRole.members.size} members in ${foundRole.toString()}`)
     }
 }
 

--- a/src/programs/WhereAreYouFromManager.ts
+++ b/src/programs/WhereAreYouFromManager.ts
@@ -1,6 +1,6 @@
 import Discord, { TextChannel } from 'discord.js';
 import Tools from '../common/tools';
-import {isRegistered} from '../common/moderator';
+import {isRegistered, textLog} from '../common/moderator';
 import flag from 'country-code-emoji';
 import { Country, countries } from "../collections/flagEmojis";
 
@@ -16,7 +16,32 @@ export default async function WhereAreYouFromManager(pMessage: Discord.Message) 
         });
 
         if(countryToAssign) {
-            const roleToAssign = pMessage.guild.roles.cache.find(role => role.name.toLowerCase().includes(countryToAssign.name.toLowerCase()));
+
+            const isOutlier = ["Australia", "United States", "United Kingdom", "Canada"].find(each => countryToAssign.title.includes(each));
+            let roleToAssign: Discord.Role;
+
+            switch (isOutlier) {
+                case "Australia":
+                    roleToAssign = pMessage.guild.roles.cache.find(role => role.name === "I'm from Australia!");
+                    break;
+                case "United Kingdom":
+                    roleToAssign = pMessage.guild.roles.cache.find(role => role.name === "I'm from the UK!");
+                    break;
+                case "United States":
+                    roleToAssign = pMessage.guild.roles.cache.find(role => role.name === "I'm from the USA!");
+                    break;
+                case "Canada":
+                    roleToAssign = pMessage.guild.roles.cache.find(role => role.name === "I'm from Canada!");
+                    break;
+                default:
+                    roleToAssign = pMessage.guild.roles.cache.find(role => role.name.toLowerCase().includes(countryToAssign.name.toLowerCase()));
+                    break;
+            }
+
+            if(!roleToAssign) {
+                textLog(`<@${pMessage.author.id}> just requested role for country ${countryToAssign.name}, but I could not find it. Please make sure this role exists.`);
+                return;
+            }
             pMessage.member.roles.add(roleToAssign);
             pMessage.react("👍")
             pMessage.member.createDM().then(dmChannel => {

--- a/src/programs/WhereAreYouFromManager.ts
+++ b/src/programs/WhereAreYouFromManager.ts
@@ -22,7 +22,7 @@ export default async function WhereAreYouFromManager(pMessage: Discord.Message) 
             pMessage.member.createDM().then(dmChannel => {
                 const rules = pMessage.guild.channels.cache.find(c => c.name === "rules");
                 const generalInfo = pMessage.guild.channels.cache.find(c => c.name === "general-info")
-                dmChannel.send(`Hey! My name is YesBot, I'm so happy to see you've made it into our world, we really hope you stick around!\n\nIn the meantime, you should checkout ${rules.toString()} and ${generalInfo.toString()} , they contain a lot of good-to-knows about our server, and what cool stuff we can do.\nIt would be awesome to know your name, could you reply to this message with your first name please? Then I can introduce you to our family :D\n\nI know Discord can be a lot to take in at first, trust me, but it's really quite a wonderful place. If you like, I can send you a video on how Discord works for our server. For the mobile version, click :iphone: , or for the desktop version, click :desktop:`)
+                dmChannel.send(`Hey! My name is YesBot, I'm so happy to see you've made it into our world, we really hope you stick around!\n\nIn the meantime, you should checkout ${rules.toString()} and ${generalInfo.toString()} , they contain a lot of good-to-knows about our server and what cool stuff you can do.\nIt would be awesome to know your name, could you reply to this message with your first name please? Then I can introduce you to our family :grin:\n\nI know Discord can be a lot to take in at first, trust me, but it's really quite a wonderful place.`)
             })
         }
     }


### PR DESCRIPTION
This change introduces the start of what will be the new user entry flow.

This iteration will still send a welcome message when a user joins, however now if they respond with an appropriate country flag or name, they will receive the role automatically and receive a DM indicating this has happened. The user can then opt to rename themselves in said DM channel.

I also added `!role search <roleName>` to get the number of users for a given searched role string.

Some added tidy up with common moderation functions.