### PR TITLE
feat: moved deadchat questions to database

### DIFF
--- a/src/entities/Deadchat.ts
+++ b/src/entities/Deadchat.ts
@@ -1,0 +1,17 @@
+import { Entity, PrimaryGeneratedColumn, Column, getConnection } from "typeorm";
+
+@Entity()
+export class DeadchatQuestion {
+    @PrimaryGeneratedColumn()
+    id: string;
+
+    @Column()
+    question: string;
+
+    @Column({ default: false, name: "is_used" })
+    isUsed: boolean;
+}
+
+export const DeadchatRepository = async () => {
+    return getConnection().getRepository(DeadchatQuestion);
+};

--- a/src/entities/Deadchat.ts
+++ b/src/entities/Deadchat.ts
@@ -8,8 +8,8 @@ export class DeadchatQuestion {
     @Column()
     question: string;
 
-    @Column({ default: false, name: "is_used" })
-    isUsed: boolean;
+    @Column({ default: new Date(), name: "last_used" })
+    lastUsed: Date;
 }
 
 export const DeadchatRepository = async () => {

--- a/src/programs/Deadchat.ts
+++ b/src/programs/Deadchat.ts
@@ -1,5 +1,4 @@
 import Discord, { TextChannel } from 'discord.js';
-import Tools from '../common/tools';
 import { DeadchatQuestion, DeadchatRepository } from '../entities/Deadchat';
 
 export default async function Deadchat(pMessage: Discord.Message) {
@@ -31,11 +30,11 @@ export default async function Deadchat(pMessage: Discord.Message) {
         .createQueryBuilder()
         .select()
         .limit(1)
-        .andWhere("is_used = false")
-        .andWhere("random() < 0.5") // To get a random-ish question (strongly biased towards the top few questions but good enough I guess)
+        .andWhere("random() < 0.5 OR id = 1") // To get a random-ish question (strongly biased towards the top few questions but good enough I guess)
+        .orderBy("last_used", "ASC")
         .getOne();
 
     pMessage.channel.send(question.question);
-    question.isUsed = true;
+    question.lastUsed = new Date();
     deadchatRepo.save(question);
 }

--- a/src/programs/Deadchat.ts
+++ b/src/programs/Deadchat.ts
@@ -29,9 +29,9 @@ export default async function Deadchat(pMessage: Discord.Message) {
     const question: DeadchatQuestion = await deadchatRepo
         .createQueryBuilder()
         .select()
-        .limit(1)
         .andWhere("random() < 0.5 OR id = 1") // To get a random-ish question (strongly biased towards the top few questions but good enough I guess)
         .orderBy("last_used", "ASC")
+        .limit(1)
         .getOne();
 
     pMessage.channel.send(question.question);

--- a/src/programs/Deadchat.ts
+++ b/src/programs/Deadchat.ts
@@ -1,22 +1,22 @@
 import Discord, { TextChannel } from 'discord.js';
 import Tools from '../common/tools';
-
+import { DeadchatQuestion, DeadchatRepository } from '../entities/Deadchat';
 
 export default async function Deadchat(pMessage: Discord.Message) {
 
-    const isDead = ((Date.now() - await (await pMessage.channel.messages.fetch({ limit: 2 })).array()[1].createdTimestamp) > 1800000) //|| pMessage.guild.name != "Yes Theory Fam";
-    const isChat = ["chat","chat-too"].includes((pMessage.channel as TextChannel).name)
-    if(!isChat) {
+    const isDead = (Date.now() - (await pMessage.channel.messages.fetch({ limit: 2 })).array()[1].createdTimestamp) > 1800000; //|| pMessage.guild.name != "Yes Theory Fam";
+    const isChat = ["chat", "chat-too"].includes((pMessage.channel as TextChannel).name)
+    if (!isChat) {
         pMessage.delete();
         pMessage.reply("you can't use this command here.").then(message => {
             setTimeout(() => {
-                message.delete()    
+                message.delete()
             }, 10000);
         })
         return;
     }
 
-    if(!isDead) {
+    if (!isDead) {
         pMessage.delete();
         pMessage.reply("Chat is not dead! You can use this command if there have been no messages in the last 30 minutes.").then(m => {
             setTimeout(() => {
@@ -26,12 +26,16 @@ export default async function Deadchat(pMessage: Discord.Message) {
         return;
     }
 
-    let deadchatQuestions = await Tools.resolveFile("deadchatQuestions");
-    const question = deadchatQuestions[Math.floor(Math.random()*deadchatQuestions.length)];
-    pMessage.channel.send(question);
-    // deadchatQuestions.splice(0, 1);
-    // Tools.writeFile("deadchatQuestions", deadchatQuestions)
+    const deadchatRepo = await DeadchatRepository();
+    const question: DeadchatQuestion = await deadchatRepo
+        .createQueryBuilder()
+        .select()
+        .limit(1)
+        .andWhere("is_used = false")
+        .andWhere("random() < 0.5") // To get a random-ish question (strongly biased towards the top few questions but good enough I guess)
+        .getOne();
 
-
-
+    pMessage.channel.send(question.question);
+    question.isUsed = true;
+    deadchatRepo.save(question);
 }


### PR DESCRIPTION
This change would get rid of both deadchatQuestions.json and usedDeadchatQuestions.json by moving the storage of the questions and their used state to the database.