### PR TITLE
feat: more flexible polls

### DIFF
--- a/src/events/MessageManager.ts
+++ b/src/events/MessageManager.ts
@@ -70,7 +70,9 @@ class MessageManager {
                 break;
 
             case "polls":
-                Poll(this.message);
+                if (this.message.author.id !== bot.user.id) {
+                    Poll(this.message);
+                }
                 // this.message.react('🇦').then(() => this.message.react('🅱️'))
                 break;
 

--- a/src/events/MessageManager.ts
+++ b/src/events/MessageManager.ts
@@ -1,5 +1,5 @@
 import  Discord, { TextChannel, User } from 'discord.js';
-import { Someone, ReactRole, StateRoleFinder, Ticket, Deadchat, WhereAreYouFromManager, GroupManager, BirthdayManager, Unassigned, ProfileManager, EasterEvent } from '../programs';
+import { Someone, ReactRole, StateRoleFinder, Ticket, Deadchat, WhereAreYouFromManager, GroupManager, BirthdayManager, Unassigned, ProfileManager, EasterEvent, Poll } from '../programs';
 import bot from "../index"
 import ExportManager from '../programs/ExportManager';
 import {USA_IMAGE_URL, CANADA_IMAGE_URL, UK_IMAGE_URL, AUSTRALIA_IMAGE_URL } from '../const'
@@ -70,8 +70,8 @@ class MessageManager {
                 break;
 
             case "polls":
-
-                this.message.react('🇦').then(() => this.message.react('🅱️'))
+                Poll(this.message);
+                // this.message.react('🇦').then(() => this.message.react('🅱️'))
                 break;
 
             case "feature-requests":

--- a/src/events/MessageManager.ts
+++ b/src/events/MessageManager.ts
@@ -73,7 +73,6 @@ class MessageManager {
                 if (this.message.author.id !== bot.user.id) {
                     Poll(this.message);
                 }
-                // this.message.react('🇦').then(() => this.message.react('🅱️'))
                 break;
 
             case "feature-requests":

--- a/src/programs/Poll.ts
+++ b/src/programs/Poll.ts
@@ -58,6 +58,16 @@ const getOptions = (messageContent: string) => {
 
 export default async function Poll(pMessage: Discord.Message) {
     const options = getOptions(pMessage.content);
+    const uniqueOptions = options.filter((value, index, self) => self.indexOf(value) === index);
+
+    if (uniqueOptions.length < 2) {
+        pMessage.reply("More than one distinct option is required!").then(message => {
+            // message.delete({timeout: 10000});
+        }).catch(console.log);
+        pMessage.delete();
+        return;
+    }
+
     for (let i = 0; i < options.length; i++) {
         await pMessage.react(options[i]);
     }

--- a/src/programs/Poll.ts
+++ b/src/programs/Poll.ts
@@ -62,7 +62,7 @@ export default async function Poll(pMessage: Discord.Message) {
 
     if (uniqueOptions.length < 2) {
         pMessage.reply("More than one distinct option is required!").then(message => {
-            // message.delete({timeout: 10000});
+            message.delete({timeout: 10000});
         }).catch(console.log);
         pMessage.delete();
         return;

--- a/src/programs/Poll.ts
+++ b/src/programs/Poll.ts
@@ -1,0 +1,64 @@
+import Discord from 'discord.js';
+
+// From http://www.unicode.org/reports/tr51/tr51-18.html#EBNF_and_Regex
+const unicodeEmojiRegex = /\p{RI}\p{RI}|\p{Emoji}(\p{Emoji_Modifier_Base}|\uFE0F\u20E3?|[\u{E0020}-\u{E007E}]+\u{E007F})?(\u{200D}\p{Emoji}(\p{Emoji_Modifier_Base}|\uFE0F\u20E3?|[\u{E0020}-\u{E007E}]+\u{E007F})?)*/gu;
+
+/**
+ * Function to find poll options in a message based on a regex.
+ * 
+ * @param messageContent The content of the message to scan for options
+ * @param anyMatchRegex A regex that checks if there is at least one match in the entire message
+ * @param actualMatchRegex A regex that extracts the option from each line
+ */
+const getPollOptions = (messageContent: string, anyMatchRegex: RegExp, actualMatchRegex: RegExp) => {
+    if (!anyMatchRegex.test(messageContent)) return [];
+
+    // Match the first word between colons, including the colons per line
+    let match = actualMatchRegex.exec(messageContent);
+
+    // Skip over the lines without match
+    while (!match) {
+        match = actualMatchRegex.exec(messageContent);
+    }
+
+    const usedEmojis = [];
+
+    // Push the matches
+    while (match) {
+        usedEmojis.push(match[1]);
+        match = actualMatchRegex.exec(messageContent)
+    }
+
+    return usedEmojis;
+}
+
+// Potentially naive approach but looking at the recent polls it's realistic
+const getOptions = (messageContent: string) => {
+    const emojis = getPollOptions(messageContent, unicodeEmojiRegex, RegExp("^\s*(" + unicodeEmojiRegex.source + ").*$", "gum"));
+    if (emojis.length > 1) return emojis;
+
+    const capitals = getPollOptions(messageContent, /^[A-Z]\p{P}/um, /^([A-Z])\p{P}.*$/gum);
+    const letterToEmoji = (letter: string) => {
+        const unicodeOffset = 0x1F1E6; //Regional Indicator A
+        const asciiOffset = "A".charCodeAt(0);
+
+        if (letter === 'B') return '🅱️';
+        const letterIndex = letter.charCodeAt(0) - asciiOffset;
+        const unicodeCodePoint = unicodeOffset + letterIndex;
+        return String.fromCodePoint(unicodeCodePoint);
+    }
+
+    if (capitals.length > 1) return capitals.map(letterToEmoji);
+
+    const defaultOptions = ['🇦', '🅱️'];
+    console.log("Couldn't find options in poll; defaulting to " + defaultOptions);
+    
+    return defaultOptions;
+}
+
+export default async function Poll(pMessage: Discord.Message) {
+    const options = getOptions(pMessage.content);
+    for (let i = 0; i < options.length; i++) {
+        await pMessage.react(options[i]);
+    }
+}

--- a/src/programs/index.ts
+++ b/src/programs/index.ts
@@ -9,6 +9,7 @@ import InitialiseTestEnvironment from './InitialiseTestEnvironment';
 import Unassigned from './Unassigned';
 import ProfileManager from './ProfileManager';
 import EasterEvent from './EasterEvent';
-import BirthdayManager from './BirthdayManager'
+import BirthdayManager from './BirthdayManager';
+import Poll from './Poll';
 
-export { Someone,BirthdayManager,EasterEvent, ReactRole, StateRoleFinder, Ticket, Deadchat, WhereAreYouFromManager, GroupManager, InitialiseTestEnvironment, Unassigned, ProfileManager }; 
+export { Someone,BirthdayManager,EasterEvent, ReactRole, StateRoleFinder, Ticket, Deadchat, WhereAreYouFromManager, GroupManager, InitialiseTestEnvironment, Unassigned, ProfileManager, Poll }; 


### PR DESCRIPTION
![](https://cdn.discordapp.com/attachments/680534043775074374/706507773143416882/polls.gif)

Polls now detect options, falling back to A/B if neither of the two attempts to find intended options brought up at least two.

The first attempt consists of checking for emojis at the beginning of a line. All found emojis are added to the array of reactions and returned.

The second attempt looks for capital letters followed by punctuation (to avoid the start of the question for example). Letters are collected, converted to regional indicators and reacted with.

ToDo: In case someone tries to cheat the bot by using the same letter or reaction twice, an error will be thrown (couldn't do this yet because reply is messing around and I don't know why).