### PR TITLE
fix: UM flag didn't resolve to US (+ BV -> Norway)

### DIFF
--- a/src/collections/flagEmojis.ts
+++ b/src/collections/flagEmojis.ts
@@ -260,8 +260,8 @@ export const countries: Country[] = [
     "code": "BV",
     "emoji": "🇧🇻",
     "unicode": "U+1F1E7 U+1F1FB",
-    "name": "Bouvet Island",
-    "title": "flag for Bouvet Island"
+    "name": "Norway",
+    "title": "flag for Norway"
   },
   {
     "code": "BW",

--- a/src/collections/flagEmojis.ts
+++ b/src/collections/flagEmojis.ts
@@ -1784,6 +1784,13 @@ export const countries: Country[] = [
 
   },
   {
+    "code": "UM",
+    "emoji": "🇺🇲",
+    "unicode": "U+1F1FA U+1F1F2",
+    "name": "USA",
+    "title": "flag for United States",
+  },
+  {
     "code": "UG",
     "emoji": "🇺🇬",
     "unicode": "U+1F1FA U+1F1EC",


### PR DESCRIPTION
The flag made from regional indicators U and M looks indentical to the US flag (see https://emojipedia.org/flag-us-outlying-islands/) which has caught plenty people from the US now.

This PR adds an entry to the flag emoji collection that lets the UM flag resolve to the US in the same way the actual US flag does.