### PR TITLE
fix: flag overrides breaking country by name

### DIFF
--- a/src/collections/flagEmojis.ts
+++ b/src/collections/flagEmojis.ts
@@ -256,13 +256,13 @@ export const countries: Country[] = [
     "title": "flag for Bhutan",
 
   },
-  // {
-  //   "code": "BV",
-  //   "emoji": "🇧🇻",
-  //   "unicode": "U+1F1E7 U+1F1FB",
-  //   "name": "Norway",
-  //   "title": "flag for Norway"
-  // },
+  {
+    "code": "BV",
+    "emoji": "🇧🇻",
+    "unicode": "U+1F1E7 U+1F1FB",
+    "name": "Norway",
+    "title": "flag for Norway"
+  },
   {
     "code": "BW",
     "emoji": "🇧🇼",
@@ -1783,13 +1783,13 @@ export const countries: Country[] = [
     "title": "flag for Ukraine",
 
   },
-  // {
-  //   "code": "UM",
-  //   "emoji": "🇺🇲",
-  //   "unicode": "U+1F1FA U+1F1F2",
-  //   "name": "USA",
-  //   "title": "flag for United States",
-  // },
+  {
+    "code": "UM",
+    "emoji": "🇺🇲",
+    "unicode": "U+1F1FA U+1F1F2",
+    "name": "USA",
+    "title": "flag for United States",
+  },
   {
     "code": "UG",
     "emoji": "🇺🇬",

--- a/src/programs/WhereAreYouFromManager.ts
+++ b/src/programs/WhereAreYouFromManager.ts
@@ -8,20 +8,19 @@ import { MODERATOR_ROLE_NAME } from '../const';
 export default async function WhereAreYouFromManager(pMessage: Discord.Message) {
 
     const newUser = !isRegistered(pMessage.member);
-    let countryToAssign: Country;
-    let count = 0
 
     if(newUser) {
-        countries.forEach((country:Country) => {
-            if(pMessage.content.includes(country.emoji) || pMessage.content.toLowerCase().includes(country.name.toLowerCase())) {
-                    countryToAssign = country;
-                    count++
-            }
+        const matchedCountries = countries.filter((country:Country) => {
+            return pMessage.content.includes(country.emoji) || pMessage.content.toLowerCase().includes(country.name.toLowerCase())
         });
-        if(count > 1) {
+        const uniqueMatches = matchedCountries.filter(({name: filterName}, index, self) => self.findIndex(({name}) => name === filterName) === index);
+
+        if(uniqueMatches.length > 1) {
             pMessage.reply("Please only tell me 1 country for now, you can ask a member of the Support team about multiple nationalities :grin:")
             return;
         }
+
+        const countryToAssign = uniqueMatches[0];
         if(countryToAssign) {
 
             const isOutlier = ["Australia", "United States", "United Kingdom", "Canada"].find(each => countryToAssign.title.includes(each));


### PR DESCRIPTION
Fixes this:

![grafik](https://user-images.githubusercontent.com/26303198/80942326-cd9e8780-8de4-11ea-8dc1-01ca5d626a20.png)

and reintroduces the flag overrides from `:flag_um:` to the US and `:flag_bv:` to Norway.