### PR TITLE
fix: timezone evaluation for countries starting with 'the'

### DIFF
--- a/src/programs/BirthdayManager.ts
+++ b/src/programs/BirthdayManager.ts
@@ -45,7 +45,7 @@ export default async function BirthdayManager(message: Message) {
 
     let birthdayAccepted;
     try {
-        birthdayAccepted = await birthdayMessage.awaitReactions(filter, { max: 1, time: 15000, errors: ['time']});
+        birthdayAccepted = await birthdayMessage.awaitReactions(filter, { max: 1, time: 15000, errors: ['time'] });
     } catch (err) {
         // timeout probably
         return
@@ -165,7 +165,7 @@ async function getUserTimezone(message: Message): Promise<string> {
     const regionIdentifierStart = 127462;
     let reactions: string[] = [];
 
-    timezones.forEach((tz, i)=> {
+    timezones.forEach((tz, i) => {
         if (stopAddReactions) return;
 
         const currentTime = new Date();
@@ -194,7 +194,7 @@ async function getUserTimezone(message: Message): Promise<string> {
 
     let received;
     try {
-        received = await sentMessage.awaitReactions(filter, { max: 1, time: 60000, errors: ['time']})
+        received = await sentMessage.awaitReactions(filter, { max: 1, time: 60000, errors: ['time'] })
     } catch (err) {
         if (err.toString() === "[object Map]") {
             await sentMessage.delete();
@@ -267,11 +267,14 @@ function timezonesFromRole(props: CountryWithRegion): readonly string[] {
     }
 
     // let's find what tz's are available for this country
+    let fixedCountry = country;
+    if (country.startsWith("the "))
+        fixedCountry = country.substring("the ".length);
 
     // REALLY
     const countries = getAllCountries();
     const countryId = Object.keys(countries)
-        .find(id => countries[id].name === country);
+        .find(id => countries[id].name === fixedCountry);
     return countries[countryId].timezones;
 }
 


### PR DESCRIPTION
Fixes a bug for people adding their birthday with a country role that starts with `I'm from the` (with the `the` being the issue):

![grafik](https://user-images.githubusercontent.com/26303198/81345807-6c630680-90b9-11ea-9b45-9dbe26b752e4.png)

![grafik](https://user-images.githubusercontent.com/26303198/81319624-378e8980-9090-11ea-8f59-2130a250b5cf.png)
