### PR TITLE
feat: rename guard for DMs

### DIFF
--- a/src/common/state.ts
+++ b/src/common/state.ts
@@ -1,0 +1,12 @@
+import { Snowflake } from "discord.js";
+
+interface State {
+  ignoredGroupDMs: Array<Snowflake>,
+}
+
+const state: State = {
+  ignoredGroupDMs: [],
+};
+
+export default state;
+export type { State };

--- a/src/events/MessageManager.ts
+++ b/src/events/MessageManager.ts
@@ -127,7 +127,10 @@ class MessageManager {
                 const nameMessage = await dmChannel.awaitMessages(() => true, { time: 60000, max: 1 });
                 removeIgnore();
                
-                if (nameMessage.size === 0) throw "No response";
+                if (nameMessage.size === 0) {
+                    requestMessage.delete();
+                    throw "No response";
+                }
 
                 const requestedName = nameMessage.first().content;
                 this.proposeNameChange(requestedName);

--- a/src/events/MessageManager.ts
+++ b/src/events/MessageManager.ts
@@ -1,9 +1,10 @@
-import  Discord, { TextChannel, User, Channel } from 'discord.js';
+import  Discord, { TextChannel, User, Channel, CollectorFilter, MessageReaction, Snowflake } from 'discord.js';
 import { Someone, ReactRole, StateRoleFinder, Ticket, Deadchat, WhereAreYouFromManager, GroupManager, BirthdayManager, Unassigned, ProfileManager, EasterEvent, PollsManager } from '../programs';
 import bot from "../index"
 import ExportManager from '../programs/ExportManager';
 import {USA_IMAGE_URL, CANADA_IMAGE_URL, UK_IMAGE_URL, AUSTRALIA_IMAGE_URL } from '../const'
 import Tools from '../common/tools';
+import state from '../common/state';
 import { hasRole, textLog, getMember } from '../common/moderator';
 
 class MessageManager {
@@ -105,8 +106,44 @@ class MessageManager {
         }
 
         async routeDm() {
-            this.message.reply("I've sent your name request to the mods, hopefully they answer soon! In the meantime, you're free to roam around the server and explore. Maybe post an introduction to get started? :grin:")
-            const message = `Username: ${this.message.author.toString()} would like to rename to "${this.message.content}". Allow?`;
+            const dmChannel = this.message.channel;
+            if (state.ignoredGroupDMs.includes(dmChannel.id)) return;
+            const removeIgnore = () => {
+                const index = state.ignoredGroupDMs.indexOf(dmChannel.id);
+                if (index > -1) {
+                    state.ignoredGroupDMs.splice(index, 1);
+                }
+            }
+
+            const nameChangeMessage = await this.message.reply("Hey, I'm just a bot! Most of what I can do, I do on the YesFam discord, so talk to me there instead! I can help you change your name, though, if you're new around here. Click the :baby: if you want to change your name!");
+            await nameChangeMessage.react("👶");
+            const filter: CollectorFilter = (reaction: MessageReaction, user: User) => reaction.emoji.name === "👶" && !user.bot;
+            try {
+                const reactions = await nameChangeMessage.awaitReactions(filter, { time: 60000, max: 1 });
+                if (reactions.size === 0) throw "No reactions";
+                
+                const requestMessage = await dmChannel.send("Okay, what's your name then? Please only respond with your name like Henry or Julie, that makes things easier for the Supports! :upside_down:");
+                state.ignoredGroupDMs.push(dmChannel.id);
+                const nameMessage = await dmChannel.awaitMessages(() => true, { time: 60000, max: 1 });
+                removeIgnore();
+               
+                if (nameMessage.size === 0) throw "No response";
+
+                const requestedName = nameMessage.first().content;
+                this.proposeNameChange(requestedName);
+                await requestMessage.delete();
+            } catch {
+                removeIgnore();
+                // Time's up; nothing to do here, really
+                dmChannel.send("Because of technical reasons I can only wait 60 seconds for a reaction. I removed the other message to not confuse you. If you need anything from me, just drop me a message!");
+            }
+
+            await nameChangeMessage.delete();
+        }
+
+        proposeNameChange = async (name: string) => {
+            this.message.reply("Perfect! I've sent your name request to the mods, hopefully they answer soon! In the meantime, you're free to roam around the server and explore. Maybe post an introduction to get started? :grin:")
+            const message = `Username: ${this.message.author.toString()} would like to rename to "${name}". Allow?`;
             const sentMessage = await textLog(message)
             sentMessage.react("✅").then(message => sentMessage.react("🚫"))
             sentMessage.awaitReactions((reaction: any, user: User) => {
@@ -117,13 +154,13 @@ class MessageManager {
                     switch (reaction.emoji.toString()) {
                         case "✅":
                             const member = getMember(this.message.author.id)
-                            member.setNickname(this.message.content)
+                            member.setNickname(name)
                             sentMessage.delete();
-                            textLog(`${this.message.author.toString()} was renamed to ${this.message.content}.`)
+                            textLog(`${this.message.author.toString()} was renamed to ${name}.`)
                             break;
                         case "🚫":
                             sentMessage.delete();
-                            textLog(`${this.message.author.toString()} was *not* renamed to ${this.message.content}.`)
+                            textLog(`${this.message.author.toString()} was *not* renamed to ${name}.`)
                             break;
                     
                         default:

--- a/src/programs/WhereAreYouFromManager.ts
+++ b/src/programs/WhereAreYouFromManager.ts
@@ -54,7 +54,7 @@ export default async function WhereAreYouFromManager(pMessage: Discord.Message) 
             pMessage.member.createDM().then(dmChannel => {
                 const rules = pMessage.guild.channels.cache.find(c => c.name === "rules");
                 const generalInfo = pMessage.guild.channels.cache.find(c => c.name === "general-info")
-                dmChannel.send(`Hey! My name is YesBot, I'm so happy to see you've made it into our world, we really hope you stick around!\n\nIn the meantime, you should checkout ${rules.toString()} and ${generalInfo.toString()} , they contain a lot of good-to-knows about our server and what cool stuff you can do.\nIt would be awesome to know your name, could you reply to this message with your first name please? Then I can introduce you to our family :grin:\n\nI know Discord can be a lot to take in at first, trust me, but it's really quite a wonderful place.`)
+                dmChannel.send(`Hey! My name is YesBot, I'm so happy to see you've made it into our world, we really hope you stick around!\n\nIn the meantime, you should checkout ${rules.toString()} and ${generalInfo.toString()} , they contain a lot of good-to-knows about our server and what cool stuff you can do.\nIf you'd like me to change your name on the server for you, just drop me a message and I will help you out! Then I can introduce you to our family :grin:\n\nI know Discord can be a lot to take in at first, trust me, but it's really quite a wonderful place.`)
             })
         }
     }


### PR DESCRIPTION
New handling for DMs to not treat everything as new nickname:

![](https://cdn.discordapp.com/attachments/700728455582580748/710543317720629358/renameguard.gif)

After 60 seconds either no reaction on the initial message or no message after being prompted for a name, the bot will remove all messages sent so far, leaving the user with this:

![](https://cdn.discordapp.com/attachments/700728455582580748/710543676605988934/unknown.png)