### PR TITLE
fix: allow group pings in the gaming category

### DIFF
--- a/src/events/MessageManager.ts
+++ b/src/events/MessageManager.ts
@@ -91,8 +91,8 @@ class MessageManager {
                 const isTextChannel = (channel: Channel): channel is TextChannel => (channel as TextChannel).name && !!(channel as TextChannel).parent;
                 if (!isTextChannel(channel)) return;
 
-                const allowedCategories = ["hobbies"];
-                const allowedChannels = ["chat", "chat-too", "gaming"];
+                const allowedCategories = ["hobbies", "gaming"];
+                const allowedChannels = ["chat", "chat-too", "learning-spanish"];
 
                 if (allowedCategories.some(category => channel.parent?.name?.toLowerCase()?.includes(category))) return true;
                 


### PR DESCRIPTION
With the changes to groups, the demands for new channels with the groups ping enabled came up.

This PR enables the Gaming category as well as learning-spanish (after a spanish learning group was created).