### PR TITLE
feat: cooldowns for group pings

### DIFF
--- a/src/entities/UserGroup.ts
+++ b/src/entities/UserGroup.ts
@@ -22,6 +22,12 @@ export class UserGroup {
     @ManyToMany(type => GroupMember)
     @JoinTable()
     members: GroupMember[];
+
+    @Column("timestamp", { name: "last_used", default: () => "'now'::timestamp - '1 hour'::interval" })
+    lastUsed: Date;
+
+    @Column({ default: 60 })
+    cooldown: number;
 }
 
 export const UserGroupRepository = async () => {


### PR DESCRIPTION
Adds new behaviour for group pings. By default all groups will receive a cooldown of 60 minutes, this can be changed per group using a new command.

Block in action:

![group-ping-cooldown](https://user-images.githubusercontent.com/26303198/82131555-aa0d1100-97d6-11ea-84c3-c03566d6df82.gif)

The message about the cooldown is removed after 10 seconds.

The PR also adds a new command for mods:
`!group changeCooldown <groupname> <newCooldown>`
will update the cooldown for a group. Example:
`!group changeCooldown CoStar 5`

The behaviour of `!group create` remains unchanged. When a new group is to be created with a cooldown other than 60 minutes, it requires a second command for now.