### PR TITLE
fix: ignore group pings that are in a blockquote

### DIFF
--- a/src/programs/GroupManager.ts
+++ b/src/programs/GroupManager.ts
@@ -79,13 +79,15 @@ export default async function GroupManager(message: Discord.Message, isConfig: b
     }
 
     else {
-        // Matches if there is at least one line containing @group that doesn't start with a >
-        const match = /^(?!>).*@group/gm;
-        if (!match.test(content)) return;
+        const lines = content.split("\n");
+        const unquoted = lines.filter(line => !line.startsWith(">")).join("\n");
+        const hasUnquotedGroupPing = unquoted.includes("@group");
+
+        if (!hasUnquotedGroupPing) return;
 
         const groupRepository = await UserGroupRepository();
 
-        const groupTriggerStart = content.substring(content.indexOf("@group"));
+        const groupTriggerStart = unquoted.substring(unquoted.indexOf("@group"));
         const args = <string[]>groupTriggerStart.split(" ");
         args.shift();
         const [requestName] = args

--- a/src/programs/GroupManager.ts
+++ b/src/programs/GroupManager.ts
@@ -79,6 +79,10 @@ export default async function GroupManager(message: Discord.Message, isConfig: b
     }
 
     else {
+        // Matches if there is at least one line containing @group that doesn't start with a >
+        const match = /^(?!>).*@group/gm;
+        if (!match.test(content)) return;
+
         const groupRepository = await UserGroupRepository();
 
         const groupTriggerStart = content.substring(content.indexOf("@group"));


### PR DESCRIPTION
I *think* this works, in tests it looks good but it is 4 in the morning and I'd be happy if someone could double check this.

Background: It happens that messages are quotes that contain a group ping. Those shouldn't cause a new group ping:

![grafik](https://user-images.githubusercontent.com/26303198/82134219-d4ba9200-97f5-11ea-8c39-a25705fcec1a.png)

This PR (somewhat lazily) fixes this by checking if there is any group ping outside quotes. That still allows this behaviour (the first one actually tries to ping group thisfails instead of something):

![grafik](https://user-images.githubusercontent.com/26303198/82134190-7b526300-97f5-11ea-81a3-2888cf9e0462.png)

But that is a problem for another PR, I guess.