### PR TITLE
fix: bot message was sometimes seen as name request

### DIFF
--- a/src/events/MessageManager.ts
+++ b/src/events/MessageManager.ts
@@ -122,7 +122,7 @@ class MessageManager {
                 
                 const requestMessage = await dmChannel.send("Okay, what's your name then? Please only respond with your name like Henry or Julie, that makes things easier for the Supports! :upside_down:");
                 state.ignoredGroupDMs.push(dmChannel.id);
-                const nameMessage = await dmChannel.awaitMessages(() => true, { time: 60000, max: 1 });
+                const nameMessage = await dmChannel.awaitMessages((_, user: User) => !user.bot, { time: 60000, max: 1 });
                 removeIgnore();
                
                 if (nameMessage.size === 0) {


### PR DESCRIPTION
While I wasn't able to reproduce the issue locally, this sometimes happened:

![grafik](https://user-images.githubusercontent.com/26303198/82483991-906f1080-9ad9-11ea-8e1b-b6daa723f7cb.png)

Adding a filter to exclude bot messages in the DMs should hopefully fix this.