### PR TITLE
feat: remove general country roles when region is added

### DIFF
--- a/src/events/GuildMemberUpdate.ts
+++ b/src/events/GuildMemberUpdate.ts
@@ -13,6 +13,19 @@ class GuildMemberUpdate {
         if(hasRole(newMember, "Buddy Project 2020") && !hasRole(oldMember, "Buddy Project 2020")) {
             BuddyProjectSignup(newMember)
         }
+
+        const regionCountries = ["Australia", "Canada", "the UK", "the USA"];
+        const findGeneralRole = (member: Discord.GuildMember | Discord.PartialGuildMember) => member.roles.cache.find(({name}) => {
+            return regionCountries.some(country => name.endsWith(`${country}!`));
+        });
+        const hasSpecificRole = (member: Discord.GuildMember | Discord.PartialGuildMember) => member.roles.cache.some(({name}) => {
+            return regionCountries.some(country => name.includes(`${country}! (`));
+        });
+
+        const generalRole = findGeneralRole(oldMember);
+        if (generalRole && hasSpecificRole(newMember)) {
+            newMember.roles.remove(generalRole);
+        }
     }
 
 }


### PR DESCRIPTION
When a guild user is changed, this checks for a change of roles from a general role to a more specific region role.

In case such a change happened, the more general role is removed.

This can be coupled with the role assigning reactions to create a more automated region assigning.

![country-general-remove-magic-thing](https://user-images.githubusercontent.com/26303198/82701650-dca08900-9c70-11ea-9677-0e94adb7eff5.gif)
