### PR TITLE
fix: a group ping followed by a newline doesn't work

### DIFF
--- a/src/programs/GroupManager.ts
+++ b/src/programs/GroupManager.ts
@@ -82,7 +82,7 @@ export default async function GroupManager(message: Discord.Message, isConfig: b
         const groupRepository = await UserGroupRepository();
 
         const groupTriggerStart = content.substring(content.indexOf("@group"));
-        const args = <string[]>groupTriggerStart.split(" ");
+        const args = <string[]>groupTriggerStart.split(/\s/g);
         args.shift();
         const [requestName] = args
         const groups = (await groupRepository.find({


### PR DESCRIPTION
Fixes a bug where this would fail to find the correct group:

```
@group something
This is something amazing
```

Because the split was exclusively done on spaces and not on whitespace.

This PR fixes that behaviour (top is before the fix, bottom with the fix):

![grafik](https://user-images.githubusercontent.com/26303198/82712825-4036b080-9c89-11ea-9de2-b654f8958259.png)
