### PR TITLE
Feat/timeout per user permissions

### DIFF
--- a/src/events/ReactionAdd.ts
+++ b/src/events/ReactionAdd.ts
@@ -2,10 +2,9 @@ import Discord, { Snowflake, User, Channel, Guild, TextChannel, Emoji, GuildCrea
 import bot from "../index"
 import Tools from '../common/tools';
 import AdventureGame from "../programs/AdventureGame"
-import { ChannelToggleRepository } from '../entities/ChannelToggle';
 import { MessageRepository } from '../entities/Message';
 import { backfillReactions } from '../programs/GroupManager';
-import { textLog } from '../common/moderator';
+import { hasRole } from '../common/moderator';
 
 class ReactionAdd {
 
@@ -93,25 +92,7 @@ class ReactionAdd {
             backfillReactions(this.messageId, this.channel.id, this.guild);
         }
 
-        const channelToggleRepository = await ChannelToggleRepository();
-        const toggle = await channelToggleRepository.findOne({
-            where: {
-                emoji: this.reaction,
-                message: this.messageId,
-            }
-        });
-
-        if (toggle !== undefined) {
-            const channel = this.guild.channels.cache.find(channel => channel.id === toggle.channel);
-            if (channel === undefined) {
-                textLog(`I can't find this channel <#${channel.id}>. Has it been deleted?`);
-                return;
-            }
-
-            await channel.updateOverwrite(this.user.id, {
-                VIEW_CHANNEL: true,
-            });
-        }
+        Tools.addPerUserPermissions(this.reaction, this.messageId, this.guild, this.guild.member(this.user));
     }
 }
 

--- a/src/events/ReactionAdd.ts
+++ b/src/events/ReactionAdd.ts
@@ -69,15 +69,6 @@ class ReactionAdd {
     }
 
     async handleChannelToggleReaction() {
-        const member = this.guild.member(this.user);
-        // Catch users who are timeouted and deny their attempts at accessing other channels
-        if (hasRole(member, "Time Out")) {
-            const reaction = this.message.reactions.cache.find(reaction => reaction.emoji.name === this.reaction);
-            reaction.users.remove(member);
-
-            return;
-        }
-
         const messageRepository = await MessageRepository();
         const storedMessage = await messageRepository.findOne({
             where: {
@@ -88,6 +79,15 @@ class ReactionAdd {
         if (storedMessage === undefined) {
             // abort if we don't know of a trigger for this message
             return
+        }
+
+        const member = this.guild.member(this.user);
+        // Catch users who are timeouted and deny their attempts at accessing other channels
+        if (hasRole(member, "Time Out")) {
+            const reaction = this.message.reactions.cache.find(reaction => reaction.emoji.name === this.reaction);
+            reaction.users.remove(member);
+
+            return;
         }
 
         // Make sure we know what channel this message is forever

--- a/src/events/ReactionAdd.ts
+++ b/src/events/ReactionAdd.ts
@@ -69,6 +69,15 @@ class ReactionAdd {
     }
 
     async handleChannelToggleReaction() {
+        const member = this.guild.member(this.user);
+        // Catch users who are timeouted and deny their attempts at accessing other channels
+        if (hasRole(member, "Time Out")) {
+            const reaction = this.message.reactions.cache.find(reaction => reaction.emoji.name === this.reaction);
+            reaction.users.remove(member);
+
+            return;
+        }
+
         const messageRepository = await MessageRepository();
         const storedMessage = await messageRepository.findOne({
             where: {

--- a/src/events/ReactionRemove.ts
+++ b/src/events/ReactionRemove.ts
@@ -58,7 +58,7 @@ class ReactionRemove {
             textLog(`I can't find this channel <#${channel.id}>. Has it been deleted?`);
             return;
         }
-        await channel.permissionOverwrites.get(this.user.id).delete();
+        await channel.permissionOverwrites.get(this.user.id)?.delete();
     }
 }
 


### PR DESCRIPTION
This adds handling for timeouted users with per user permissions.

When a user receives a timeout, their per user permissions in all channels of the category channels gaming, hobbies and learning languages are removed.
When a timeout is lifted, the reactions of the first message of list-of-hobbies, list-of-games and list-of-languages are scanned for reactions the user whose timeout was lifted has clicked. The per user permissions for the respective channels will then be restored.
Trying to click a reaction while in timeout will untoggle it when it would have given access to a channel.