### PR TITLE
feat: guard against dms from non-members

### DIFF
--- a/src/events/MessageManager.ts
+++ b/src/events/MessageManager.ts
@@ -114,7 +114,14 @@ class MessageManager {
         }
 
         async routeDm() {
+            const member = getMember(this.message.author.id);
             const dmChannel = this.message.channel;
+
+            if (!member) {
+                dmChannel.send("Hey, I am the bot of the Yes Theory Fam Discord Server :) Looks like you are not on it currently, so I cannot really do a lot for you. If you'd like to join, click here: https://discord.gg/yestheory");
+                return;
+            }
+
             if (state.ignoredGroupDMs.includes(dmChannel.id)) return;
             const removeIgnore = () => {
                 const index = state.ignoredGroupDMs.indexOf(dmChannel.id);


### PR DESCRIPTION
Quick win: When you are not on the server and DM the bot, you are greeted with a short message informing you that you are not on the server including a link to it.

This guards against people who are not on the server, who could attempt to change their name, leading to the bot trying to call `setNickname` on an undefined object (if I am not mistaken).