### PR TITLE
fix: birthday timezones for czech republic

### DIFF
--- a/src/programs/BirthdayManager.ts
+++ b/src/programs/BirthdayManager.ts
@@ -277,6 +277,9 @@ function timezonesFromRole(props: CountryWithRegion): readonly string[] {
             return getCountry("CA").timezones
                 .filter(tz => tz.startsWith("Canada/"));
         }
+        case "Czech Republic": {
+            return getCountry("CZ").timezones;
+        }
     }
 
     // let's find what tz's are available for this country


### PR DESCRIPTION
Adds another timezone override.
The timezones library has CZ stored as Czechia while the server has it as Czech Republic so we have to work around that.